### PR TITLE
Added loader for photo/doc verification and improved Pickup Request UI

### DIFF
--- a/backend/warehouse-server/src/shared/cloudinary.service.ts
+++ b/backend/warehouse-server/src/shared/cloudinary.service.ts
@@ -47,14 +47,17 @@ export class CloudinaryService {
       const base64String = file.buffer.toString('base64');
       const dataUri = `data:${file.mimetype};base64,${base64String}`;
 
+      const isImage = file.mimetype.startsWith('image/');
+      const resourceType = isImage ? 'image' : 'auto';
+
       // Upload to Cloudinary
       const result = await cloudinary.uploader.upload(dataUri, {
-        folder: folder,
-        resource_type: file.mimetype.startsWith('image/') ? 'image' : 'raw',
+        folder,
+        resource_type: resourceType,
         public_id: `${Date.now()}-${file.originalname.replace(/\.[^/.]+$/, '')}`,
         overwrite: false,
         invalidate: true,
-        transformation: file.mimetype.startsWith('image/')
+        transformation: isImage
           ? [{ quality: 'auto' }, { fetch_format: 'auto' }]
           : [],
       });

--- a/frontend/admin/src/components/Modals/RegisterPackageModal.tsx
+++ b/frontend/admin/src/components/Modals/RegisterPackageModal.tsx
@@ -141,8 +141,8 @@ const RegisterPackageModal: React.FC<RegisterPackageModalProps> = ({ open, onClo
     if (!formData.trackingNo) {
       newErrors.trackingNo = "Reference Tracking is required";
     }
-    if (!/^\d{5,15}$/.test(formData.trackingNo)) {
-      newErrors.trackingNo = "Tracking number must be between 5 and 15 digits.";
+    if (formData.trackingNo.length < 5 || formData.trackingNo.length > 15) {
+      newErrors.trackingNo = "Tracking number must be between 5 and 15 characters.";
     }
 
     // Check if at least one piece has weight

--- a/frontend/admin/src/components/Modals/RegisterPackageModal/FormFields.tsx
+++ b/frontend/admin/src/components/Modals/RegisterPackageModal/FormFields.tsx
@@ -100,8 +100,8 @@ const FormFields: React.FC<FormFieldsProps> = ({
           value={formData.trackingNo || ""}
           onChange={(e) => {
             const value = e.target.value;
-            // Allow only digits and max 15 characters
-            if (/^\d*$/.test(value) && value.length <= 15) {
+            // Allow any characters but limit to max 15
+            if (value.length <= 15) {
               onInputChange("trackingNo", value);
             }
           }}

--- a/frontend/admin/src/components/PackageDetail/ActionLogsSection.tsx
+++ b/frontend/admin/src/components/PackageDetail/ActionLogsSection.tsx
@@ -51,6 +51,7 @@ const ActionLogsSection: React.FC<ActionLogsSectionProps> = ({
   const [isDragOver, setIsDragOver] = useState(false);
   const [uploadModalOpen, setUploadModalOpen] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [isStatusUpdating, setIsStatusUpdating] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -68,11 +69,8 @@ const ActionLogsSection: React.FC<ActionLogsSectionProps> = ({
     } catch (err) {
       console.error('Failed to update package status:', err);
       toast.error('Failed to update package status');
+      throw err;
     }
-  };
-
-  const handleAdminCheck = (checked: boolean) => {
-    setIsAdminChecked(checked);
   };
 
   const handleOpenUploadModal = () => setUploadModalOpen(true);
@@ -176,6 +174,23 @@ const ActionLogsSection: React.FC<ActionLogsSectionProps> = ({
   };
   const handleClick = () => fileInputRef.current?.click();
 
+  const handleStatusToggle = async () => {
+    if (isDiscarded || isStatusUpdating || uploadedDocuments.length === 0) return;
+
+    if (actionLogStatus === 'In Review' && packageItems.length === 0) {
+      toast.error('Please add package items before verifying.');
+      return;
+    }
+
+    setIsStatusUpdating(true);
+    try {
+      const newStatus = visualChecked ? 'In Review' : 'Ready To Send';
+      await handleStatusChange(newStatus);
+    } finally {
+      setIsStatusUpdating(false);
+    }
+  };
+
   const allowedStatuses = [
     'Ready To Send',
     'Request Ship',
@@ -224,6 +239,7 @@ const ActionLogsSection: React.FC<ActionLogsSectionProps> = ({
               {/* Status Indicator - Clickable Checkbox */}
               <Box
                 sx={{
+                  position: 'relative',
                   width: 16,
                   height: 16,
                   borderRadius: '50%',
@@ -233,38 +249,35 @@ const ActionLogsSection: React.FC<ActionLogsSectionProps> = ({
                   alignItems: 'center',
                   justifyContent: 'center',
                   mt: 0.5,
-                  cursor: isDiscarded ? 'not-allowed' : uploadedDocuments.length > 0 ? 'pointer' : 'not-allowed',
-                  opacity: isDiscarded ? 0.4 : uploadedDocuments.length > 0 ? 1 : 0.5,
+                  cursor: isDiscarded || isStatusUpdating ? 'not-allowed' : uploadedDocuments.length > 0 ? 'pointer' : 'not-allowed',
+                  opacity: isDiscarded || isStatusUpdating ? 0.5 : uploadedDocuments.length > 0 ? 1 : 0.5,
                   '&:hover': {
-                    bgcolor: uploadedDocuments.length > 0
-                      ? (visualChecked ? '#16a34a' : '#fef2f2')
-                      : 'transparent'
+                    bgcolor: isStatusUpdating || isDiscarded || uploadedDocuments.length === 0
+                      ? 'transparent'
+                      : (visualChecked ? '#16a34a' : '#fef2f2')
                   }
                 }}
-                onClick={() => {
-                  if (isDiscarded) return;
-
-                  if (actionLogStatus === 'In Review' && packageItems.length === 0) {
-                    toast.error('Please add package items before verifying.');
-                    return;
-                  }
-
-                  // Only allow clicking if documents are uploaded
-                  if (uploadedDocuments.length === 0) return;
-
-                  // Toggle visual check state
-                  const newCheckedState = !visualChecked;
-                  handleAdminCheck(newCheckedState);
-
-                  // Update status based on admin check
-                  if (newCheckedState) {
-                    handleStatusChange('Ready To Send');
-                  } else {
-                    handleStatusChange('In Review');
-                  }
-                }}
+                onClick={handleStatusToggle}
               >
-                {visualChecked ? (
+                 {isStatusUpdating ? (
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      top: '50%',
+                      left: '50%',
+                      transform: 'translate(-50%, -50%)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <CircularProgress
+                      size={18}
+                      thickness={9}
+                      sx={{ color: '#3b82f6'}}
+                    />
+                  </Box>
+                ) : visualChecked ? (
                   <Box sx={{
                     width: 8,
                     height: 8,
@@ -278,7 +291,7 @@ const ActionLogsSection: React.FC<ActionLogsSectionProps> = ({
                       borderLeft: '2px solid white',
                       borderBottom: '2px solid white',
                       transform: 'rotate(-45deg)',
-                      marginTop: '-1px'
+                      marginTop: '-2px'
                     }} />
                   </Box>
                 ) : null}

--- a/frontend/admin/src/components/PackageDetail/ActionLogsSection.tsx
+++ b/frontend/admin/src/components/PackageDetail/ActionLogsSection.tsx
@@ -16,17 +16,10 @@ interface UploadedDocument {
   status?: 'uploading' | 'completed' | 'failed';
 }
 
-interface PackageItem {
-  id: string;
-  name: string;
-  quantity: number;
-}
-
 interface ActionLogsSectionProps {
   packageId: string;
   initialStatus: { label: string; value: string };
   initialDocuments: UploadedDocument[];
-  packageItems: PackageItem[];
   packageCreationData: {
     createdBy: string;
     createdAt: string;
@@ -39,7 +32,6 @@ const ActionLogsSection: React.FC<ActionLogsSectionProps> = ({
   packageId,
   initialStatus,
   initialDocuments,
-  packageItems,
   packageCreationData,
   onActionLogUpdate,
   isDiscarded,
@@ -181,11 +173,6 @@ const ActionLogsSection: React.FC<ActionLogsSectionProps> = ({
 
   const handleStatusToggle = async () => {
     if (isDiscarded || isStatusUpdating || uploadedDocuments.length === 0) return;
-
-    if (actionLogStatus === 'In Review' && packageItems.length === 0) {
-      toast.error('Please add package items before verifying.');
-      return;
-    }
 
     setIsStatusUpdating(true);
     try {

--- a/frontend/admin/src/pages/PackageDetail.tsx
+++ b/frontend/admin/src/pages/PackageDetail.tsx
@@ -245,20 +245,6 @@ const PackageDetail: React.FC = () => {
         pageSubtitle={packageData.package_id}
       />
       {showDiscardedMessage}
-      {packageItems.length === 0 && (
-        <Box
-          sx={{
-            mb: 2,
-            p: 2,
-            bgcolor: '#fee2e2',
-            borderRadius: 1
-          }}
-        >
-          <Typography sx={{ color: '#b91c1c', fontWeight: 500 }}>
-            Please enter package items below.
-          </Typography>
-        </Box>
-      )}
 
         <PackageHeader 
           packageData={displayPackageData}
@@ -308,7 +294,6 @@ const PackageDetail: React.FC = () => {
             packageId={displayPackageData.actual_id}
             initialStatus={displayPackageData.status}
             initialDocuments={uploadedDocuments}
-            packageItems={packageItems}
             packageCreationData={{
               createdBy: displayPackageData.createdBy,
               createdAt: displayPackageData.createdAt,

--- a/frontend/admin/src/pages/PickupRequests.tsx
+++ b/frontend/admin/src/pages/PickupRequests.tsx
@@ -79,7 +79,20 @@ const PickupRequests: React.FC = () => {
     },
     {
       header: 'Pickup Location',
-      cell: (row) => <Typography variant="body2">{row.pickupLocation}</Typography>,
+      cell: (row) => (
+        <Typography
+          variant="body2"
+          sx={{
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            maxWidth: "250px",
+            display: "block",
+          }}
+          title={row.pickupLocation}
+        >
+            {row.pickupLocation}
+          </Typography>
+      ),
       width: '30%',
     },
     {

--- a/frontend/warehouse-app/src/app/pickup-request/create-request/page.tsx
+++ b/frontend/warehouse-app/src/app/pickup-request/create-request/page.tsx
@@ -131,6 +131,7 @@ function CreatePickupRequestPageContent() {
               placeholder="Enter full address"
               size="small"
               required
+              inputProps={{ maxLength: 100 }}
             />
             <Typography
               variant="caption"
@@ -151,6 +152,7 @@ function CreatePickupRequestPageContent() {
               placeholder="Enter supplier/shop name"
               size="small"
               required
+              inputProps={{ maxLength: 30 }}
             />
           </Box>
 
@@ -165,6 +167,7 @@ function CreatePickupRequestPageContent() {
                 placeholder="Enter supplier contact number"
                 size="small"
                 required
+                inputProps={{ maxLength: 10 }}
               />
             </Box>
             <Box sx={{ flex: 1 }}>
@@ -176,6 +179,7 @@ function CreatePickupRequestPageContent() {
                 fullWidth
                 placeholder="Enter supplier alternative contact number"
                 size="small"
+                inputProps={{ maxLength: 10 }}
               />
             </Box>
           </Box>
@@ -191,6 +195,7 @@ function CreatePickupRequestPageContent() {
                 placeholder="Enter number of pcs/box to pickup"
                 size="small"
                 required
+                inputProps={{ maxLength: 5 }}
               />
             </Box>
             <Box sx={{ flex: 1 }}>
@@ -203,6 +208,7 @@ function CreatePickupRequestPageContent() {
                 placeholder="Enter Estimate weight in Kg"
                 size="small"
                 required
+                inputProps={{ maxLength: 5 }}
               />
             </Box>
           </Box>
@@ -219,6 +225,7 @@ function CreatePickupRequestPageContent() {
               multiline
               rows={4}
               required
+              inputProps={{ maxLength: 300 }}
             />
             <Typography
               variant="caption"
@@ -240,6 +247,7 @@ function CreatePickupRequestPageContent() {
               size="small"
               multiline
               rows={4}
+              inputProps={{ maxLength: 200 }}
             />
           </Box>
 

--- a/frontend/warehouse-app/src/app/pickup-request/page.tsx
+++ b/frontend/warehouse-app/src/app/pickup-request/page.tsx
@@ -133,7 +133,20 @@ export default function PickupRequestPage() {
 
                       <Box sx={{ flexGrow: 1, minWidth: 0 }}>
                         <Typography variant="caption" color="text.secondary">Pickup Location</Typography>
-                        <Typography variant="body2" sx={{color: "text.primary" }}>{req.pickup_address}</Typography>
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            color: "text.primary",
+                            wordBreak: "break-word",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            display: "-webkit-box",
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: "vertical", 
+                          }}
+                        >
+                          {req.pickup_address}
+                        </Typography>
                       </Box>
 
                       <Box sx={{ flexShrink: 0, width: "18%" }}>


### PR DESCRIPTION
- Added a loader while verifying photos and documents
- Fixed UI for Pickup Request, especially for pickup_address
- Limited input fields while creating a Pickup Request
- Replaced "raw" resource type with "auto" for non-image files in Cloudinary service
- Removed digits-only restriction for Reference Tracking Number
- Enabled photo/doc verification even when Package Items are not added or available
- Removed warning banner display when Package Items are not added