### PR TITLE
Introduced context to reduce prop drilling in shipment admin

### DIFF
--- a/frontend/admin/src/components/PickupRequests/Detail/DetailItem.tsx
+++ b/frontend/admin/src/components/PickupRequests/Detail/DetailItem.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Box, Typography } from "@mui/material";
+
+interface DetailItemProps {
+  label: string;
+  value: string | number | undefined;
+}
+
+const DetailItem: React.FC<DetailItemProps> = ({ label, value }) => (
+  <Box>
+    <Typography
+      variant="caption"
+      color="text.secondary"
+      sx={{ 
+        display: 'block', 
+        mb: 0.75,
+        fontSize: '0.75rem',
+        fontWeight: 600,
+        letterSpacing: '0.025em',
+        textTransform: 'uppercase',
+      }}
+    >
+      {label}
+    </Typography>
+    <Typography 
+      variant="body2" 
+      sx={{ 
+        whiteSpace: 'pre-wrap',
+        fontSize: '0.875rem',
+        fontWeight: 500,
+        color: 'text.primary',
+        lineHeight: 1.5,
+      }}
+    >
+      {value || "-"}
+    </Typography>
+  </Box>
+);
+
+export default DetailItem;

--- a/frontend/admin/src/components/PickupRequests/Detail/PickupRequestActionButtons.tsx
+++ b/frontend/admin/src/components/PickupRequests/Detail/PickupRequestActionButtons.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Box } from '@mui/material';
+
+import ActionButton from '../../common/ActionButton';
+import { PICKUP_REQUEST_ACTIONS } from '../../../utils/pickupRequestActions';
+import type { TrackingStatusValue } from '../../../types';
+
+interface PickupRequestActionButtonsProps {
+  status: string;
+  loading: boolean;
+  onOpenModal: () => void;
+  onStatusUpdate: (status: TrackingStatusValue) => void;
+}
+
+const PickupRequestActionButtons: React.FC<PickupRequestActionButtonsProps> = ({
+  status,
+  loading,
+  onOpenModal,
+  onStatusUpdate,
+}) => {
+  const actions = PICKUP_REQUEST_ACTIONS[status] || [];
+
+  if (!actions.length) return null;
+
+  return (
+    <Box sx={{ display: 'flex', gap: 1.5 }}>
+      {actions.map((action) => (
+        <ActionButton
+          key={action.label}
+          label={action.label}
+          color={action.color}
+          loading={loading}
+          onClick={() => {
+            if (action.requiresModal) {
+              onOpenModal();
+            } else if (action.statusToUpdate) {
+              onStatusUpdate(action.statusToUpdate);
+            }
+          }}
+        />
+      ))}
+    </Box>
+  );
+};
+
+export default PickupRequestActionButtons;

--- a/frontend/admin/src/components/PickupRequests/Detail/RequestDetailContent.tsx
+++ b/frontend/admin/src/components/PickupRequests/Detail/RequestDetailContent.tsx
@@ -1,69 +1,47 @@
 import React from 'react';
 import { Box } from '@mui/material';
 
-import RequestDetails, { type RequestDetailsData } from './RequestDetails';
+import RequestDetails from './RequestDetails';
 import TrackingStatus, { type Status } from '../../../components/common/Tracking/TrackingStatus';
 import { formatDateTime } from '../../../utils/formatDateTime';
 import { formatWithPlaceholders } from '../../../utils/formatPlaceholder';
+import { PICKUP_STATUS_TO_STEP_ID_MAPPING, PICKUP_TRACKING_STEPS } from '../../../utils/trackingSteps';
+import type { PickupRequestData, TrackingRequest } from '../../../types';
 
-interface User {
-  id: string;
-  name: string;
-}
-
-interface TrackingRequest {
-  id: string;
-  status: string;
-  created_at: string;
-}
-
-interface RequestData extends RequestDetailsData {
-  id: string;
-  status: string;
-  user: User;
-  tracking_requests?: TrackingRequest[];
-  [key: string]: unknown;
-}
-
-const PICKUP_TRACKING_STEPS = [
-  { id: 'REQUESTED', title: 'Requested', description: 'Requested by {userName}' },
-  { id: 'QUOTED', title: 'Quotation Ready', description: 'Quoted for {userName}', defaultDescription: 'Quotation is not ready yet!' },
-  { id: 'CONFIRMED', title: 'Confirmed', description: 'Confirmed by {userName}', defaultDescription: 'Waiting for confirmation!' },
-  { id: 'PICKED', title: 'Picked', description: 'Picked by {userName}', defaultDescription: 'Waiting for complete' },
-];
-
-const STATUS_TO_STEP_ID_MAPPING: Record<string, string> = {
-  REQUESTED: 'REQUESTED',
-  QUOTED: 'QUOTED',
-  CONFIRMED: 'CONFIRMED',
-  PICKED: 'PICKED',
-};
-
-const RequestDetailContent: React.FC<{ request: RequestData }> = ({ request }) => {
-  //TODO: Needs to improve this code
+const RequestDetailContent: React.FC<{ request: PickupRequestData }> = ({ request }) => {
   const prepareTrackingData = () => {
+    const statuses = buildTrackingStatuses(request);
+
+    const currentStageId = getCurrentStageId(request, statuses);
+    
+    resetFutureStepsIfRejected(request, statuses, currentStageId);
+
+    return { statuses, currentStageId };
+  };
+
+  const findHistoryItemForStep = (stepId: string, trackingHistory: TrackingRequest[]) => {
+    return trackingHistory.find(track => {
+      const upperCaseStatus = track.status.toUpperCase();
+      return (
+        PICKUP_STATUS_TO_STEP_ID_MAPPING[upperCaseStatus] === stepId ||
+        upperCaseStatus === stepId
+      );
+    });
+  };
+
+  const buildTrackingStatuses = (request: PickupRequestData): Status[] => {
     const trackingHistory = request.tracking_requests || [];
-    const isRejected = request.status.toUpperCase() === 'REJECTED';
+    const userName = request.user.name;
 
-    const statuses: Status[] = PICKUP_TRACKING_STEPS.map(step => {
-      let description = step.defaultDescription || '';
-      let date: string | undefined = undefined;
-      let isComplete = false;
-      const userName = request.user.name;
+    return PICKUP_TRACKING_STEPS.map(step => {
+      const historyItem = findHistoryItemForStep(step.id, trackingHistory);
 
-      const historyItem = trackingHistory.find( track => {
-        const upperCaseStatus = track.status.toUpperCase();
-        return STATUS_TO_STEP_ID_MAPPING[upperCaseStatus] === step.id || upperCaseStatus === step.id;
-      });
+      const isComplete = Boolean(historyItem);
+      const date = historyItem?.created_at;
 
-      if (historyItem) {
-        isComplete = true;
-        date = historyItem.created_at;
-      }
-      
-      if (isComplete) {
-        description = formatWithPlaceholders(step.description, { userName });
-      }
+      const description = isComplete
+        ? formatWithPlaceholders(step.description, { userName })
+        : step.defaultDescription || '';
 
       return {
         id: step.id,
@@ -72,31 +50,45 @@ const RequestDetailContent: React.FC<{ request: RequestData }> = ({ request }) =
         date: formatDateTime(date),
       };
     });
-    
-    let currentStageId: string;
+  };
+
+  const getCurrentStageId = (request: PickupRequestData, statuses: Status[]): string => {
     const upperCaseStatus = request.status.toUpperCase();
-    const mappedId = STATUS_TO_STEP_ID_MAPPING[upperCaseStatus];
+    const isRejected = upperCaseStatus === 'REJECTED';
+    const mappedId = PICKUP_STATUS_TO_STEP_ID_MAPPING[upperCaseStatus];
 
-    if (mappedId && !isRejected) {
-      currentStageId = mappedId;
-    } else {
-      const lastCompletedStep = [...statuses].reverse().find(s => s.date && s.date.trim() !== '');
-      currentStageId = lastCompletedStep ? (lastCompletedStep.id as string) : 'REQUESTED';
+    if (mappedId && !isRejected) return mappedId;
+
+    const lastCompletedStep = [...statuses]
+      .reverse()
+      .find(status => status.date && status.date.trim() !== '');
+
+    return lastCompletedStep ? (lastCompletedStep.id as string) : 'REQUESTED';
+  };
+
+  const resetFutureStepsIfRejected = (
+    request: PickupRequestData,
+    statuses: Status[],
+    currentStageId: string
+  ) => {
+    const isRejected = request.status.toUpperCase() === 'REJECTED';
+
+    if (!isRejected) return;
+
+    const currentStageIndex = statuses.findIndex(
+      status => status.id === currentStageId
+    );
+
+    if (currentStageIndex === -1) return;
+
+    for (let stageIndex = currentStageIndex + 1; stageIndex < statuses.length; stageIndex++) {
+      const originalStep = PICKUP_TRACKING_STEPS.find(
+        status => status.id === statuses[stageIndex].id
+      );
+
+      statuses[stageIndex].date = formatDateTime(undefined);
+      statuses[stageIndex].description = originalStep?.defaultDescription || '';
     }
-
-    if (isRejected) {
-      const currentStageIndex = statuses.findIndex(s => s.id === currentStageId);
-      if (currentStageIndex > -1) {
-        for (let i = currentStageIndex + 1; i < statuses.length; i++) {
-          const originalStep = PICKUP_TRACKING_STEPS.find(s => s.id === statuses[i].id);
-
-          statuses[i].date = formatDateTime(undefined);
-          statuses[i].description = originalStep?.defaultDescription || '';
-        }
-      }
-    }
-
-    return { statuses, currentStageId };
   };
 
   const { statuses, currentStageId } = prepareTrackingData();

--- a/frontend/admin/src/components/PickupRequests/Detail/RequestDetailHeader.tsx
+++ b/frontend/admin/src/components/PickupRequests/Detail/RequestDetailHeader.tsx
@@ -1,15 +1,12 @@
 import React, { useState } from 'react';
-import { Box, Typography, Button, TextField } from '@mui/material';
 
 import { updatePickupRequestStatus } from '../../../services/api.services';
 import RequestHeader from '../../common/RequestHeader';
-import Modal from '../../common/Modal';
-import ActionButton from '../../common/ActionButton';
+import PickupRequestActionButtons from './PickupRequestActionButtons';
+import SendQuotationModal from './SendQuotationModal';
 import { TRACKING_STATUS } from '../../../utils/trackingConfig';
 import { getChipStyles } from '../../../utils/pickupStatus';
-import { numberInputStyle } from '../../../styles/numberInputStyle';
-
-type TrackingStatusValue = (typeof TRACKING_STATUS)[keyof typeof TRACKING_STATUS];
+import type { TrackingStatusValue } from '../../../types';
 
 interface Users {
   id: string;
@@ -33,17 +30,11 @@ interface RequestDetailHeaderProps {
 const RequestDetailHeader: React.FC<RequestDetailHeaderProps> = ({ request, onStatusUpdate }) => {
   const [loading, setLoading] = useState(false);
   const [openModal, setOpenModal] = useState(false);
-  const [price, setPrice] = useState('');
 
   const normalizedStatus = request.status.toUpperCase();
   const chipStyles = getChipStyles(normalizedStatus);
 
   const handleOpenModal = () => setOpenModal(true);
-
-  const handleCloseModal = () => {
-    setPrice('');
-    setOpenModal(false);
-  }
 
   const handleStatusUpdate = async (status: TrackingStatusValue, price?: number) => {
     try {
@@ -51,7 +42,7 @@ const RequestDetailHeader: React.FC<RequestDetailHeaderProps> = ({ request, onSt
       await updatePickupRequestStatus(request.id, status, price);
       onStatusUpdate();
       if (status === TRACKING_STATUS.QUOTED) {
-        handleCloseModal();
+        setOpenModal(false);
       }
     } catch (err) {
       console.error(err);
@@ -60,43 +51,12 @@ const RequestDetailHeader: React.FC<RequestDetailHeaderProps> = ({ request, onSt
     }
   };
 
-  const userForHeader = {
+  const user = {
     name: request.user.name,
     email: request.user.email,
     phone: request.user.phone_number,
     suite_no: request.user.suite_no,
   };
-
-  const renderActionButtons = () => (
-    <Box sx={{ display: "flex", gap: 1.5 }}>
-      {normalizedStatus === "REQUESTED" && (
-        <ActionButton
-          label="Send Quotation"
-          onClick={handleOpenModal}
-          color="primary"
-          loading={loading}
-        />
-      )}
-
-      {normalizedStatus === "QUOTED" && (
-        <ActionButton
-          label="Reject"
-          onClick={() => handleStatusUpdate(TRACKING_STATUS.CANCELLED)}
-          color="danger"
-          loading={loading}
-        />
-      )}
-
-      {normalizedStatus === "CONFIRMED" && (
-        <ActionButton
-          label="Complete"
-          onClick={() => handleStatusUpdate(TRACKING_STATUS.PICKED)}
-          color="primary"
-          loading={loading}
-        />
-      )}
-    </Box>
-  );
 
   return (
     <>
@@ -108,38 +68,24 @@ const RequestDetailHeader: React.FC<RequestDetailHeaderProps> = ({ request, onSt
           color: chipStyles.color,
           bgColor: chipStyles.backgroundColor,
         }}
-        user={userForHeader}
-        actionButtons={renderActionButtons()}
+        user={user}
+        actionButtons={
+          <PickupRequestActionButtons
+            status={normalizedStatus}
+            loading={loading}
+            onOpenModal={handleOpenModal}
+            onStatusUpdate={handleStatusUpdate}
+          />
+        }
       />
 
-      <Modal open={openModal} onClose={handleCloseModal} title="Send Quotation ($)">
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <TextField
-            label="Quotation Price ($)"
-            type="number"
-            fullWidth
-            value={price}
-            onChange={(e) => {
-              if (e.target.value.length <= 7) {
-                setPrice(e.target.value);
-              }
-            }}
-            sx={numberInputStyle}
-          />
-          {price && (
-            <Typography variant="body2" color="text.secondary">
-              Total: ${price}
-            </Typography>
-          )}
-          <Button
-            variant="contained"
-            onClick={() => handleStatusUpdate(TRACKING_STATUS.QUOTED, Number(price))}
-            disabled={loading || !price}
-          >
-            {loading ? 'Sending...' : 'Confirm'}
-          </Button>
-        </Box>
-      </Modal>
+      <SendQuotationModal
+        requestId={request.id}
+        open={openModal}
+        loading={loading}
+        onClose={() => setOpenModal(false)}
+        onSubmit={handleStatusUpdate}
+      />
     </>
   );
 };

--- a/frontend/admin/src/components/PickupRequests/Detail/RequestDetails.tsx
+++ b/frontend/admin/src/components/PickupRequests/Detail/RequestDetails.tsx
@@ -1,57 +1,11 @@
 import React from 'react';
 import { Box, Typography, Paper } from '@mui/material';
 
-interface DetailItemProps {
-  label: string;
-  value: string | number | undefined;
-}
-
-const DetailItem: React.FC<DetailItemProps> = ({ label, value }) => (
-  <Box>
-    <Typography
-      variant="caption"
-      color="text.secondary"
-      sx={{ 
-        display: 'block', 
-        mb: 0.75,
-        fontSize: '0.75rem',
-        fontWeight: 600,
-        letterSpacing: '0.025em',
-        textTransform: 'uppercase',
-      }}
-    >
-      {label}
-    </Typography>
-    <Typography 
-      variant="body2" 
-      sx={{ 
-        whiteSpace: 'pre-wrap',
-        fontSize: '0.875rem',
-        fontWeight: 500,
-        color: 'text.primary',
-        lineHeight: 1.5,
-      }}
-    >
-      {value || "-"}
-    </Typography>
-  </Box>
-);
-
-export interface RequestDetailsData {
-  status: string;
-  pickup_address: string;
-  supplier_name: string;
-  supplier_phone_number: string;
-  pcs_box: number;
-  est_weight: string;
-  pkg_details: string;
-  price?: string;
-  total_mvr?: string;
-  remarks?: string;
-}
+import DetailItem from './DetailItem';
+import type { PickupRequestData } from '../../../types';
 
 interface RequestDetailsProps {
-  details: RequestDetailsData;
+  details: PickupRequestData;
 }
 
 const RequestDetails: React.FC<RequestDetailsProps> = ({ details }) => {
@@ -120,7 +74,7 @@ const RequestDetails: React.FC<RequestDetailsProps> = ({ details }) => {
 
           <Box sx={{ gridColumn: '1 / -1' }}>
             {showQuotationDetails && (
-                <DetailItem label="Customer Remarks" value={details.remarks} />
+              <DetailItem label="Customer Remarks" value={details.remarks} />
             )}
           </Box>
         </Box>

--- a/frontend/admin/src/components/PickupRequests/Detail/SendQuotationModal.tsx
+++ b/frontend/admin/src/components/PickupRequests/Detail/SendQuotationModal.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Box, Typography, Button, TextField } from '@mui/material';
+
+import Modal from '../../common/Modal';
+import { TRACKING_STATUS } from '../../../utils/trackingConfig';
+import { numberInputStyle } from '../../../styles/numberInputStyle';
+import type { TrackingStatusValue } from '../../../types';
+
+interface SendQuotationModalProps {
+  requestId: string;
+  open: boolean;
+  loading: boolean;
+  onClose: () => void;
+  onSubmit: (status: TrackingStatusValue, price?: number) => Promise<void>;
+}
+
+const SendQuotationModal: React.FC<SendQuotationModalProps> = ({
+  open,
+  loading,
+  onClose,
+  onSubmit,
+}) => {
+  const [price, setPrice] = useState('');
+
+  const handleClose = () => {
+    setPrice('');
+    onClose();
+  };
+
+  const handleConfirm = async () => {
+    await onSubmit(TRACKING_STATUS.QUOTED, Number(price));
+    setPrice('');
+  };
+
+  return (
+    <Modal open={open} onClose={handleClose} title="Send Quotation ($)">
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <TextField
+          label="Quotation Price ($)"
+          type="number"
+          fullWidth
+          value={price}
+          onChange={(e) => {
+            if (e.target.value.length <= 7) {
+              setPrice(e.target.value);
+            }
+          }}
+          sx={numberInputStyle}
+        />
+
+        {price && (
+          <Typography variant="body2" color="text.secondary">
+            Total: ${price}
+          </Typography>
+        )}
+
+        <Button
+          variant="contained"
+          onClick={handleConfirm}
+          disabled={loading || !price}
+        >
+          {loading ? 'Sending...' : 'Confirm'}
+        </Button>
+      </Box>
+    </Modal>
+  );
+};
+
+export default SendQuotationModal;

--- a/frontend/admin/src/components/PreArrivals/PreArrivalsTable.tsx
+++ b/frontend/admin/src/components/PreArrivals/PreArrivalsTable.tsx
@@ -1,12 +1,9 @@
-import React, { useEffect, useState } from 'react';
-import { Box, Typography, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Chip, IconButton } from '@mui/material';
-import { Visibility as VisibilityIcon, MoreVert as MoreVertIcon } from '@mui/icons-material';
+import React from 'react';
+import { Paper, Table, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+
+import PreArrivalsTableBody from './PreArrivalsTableBody';
+import { PRE_ARRIVALS_TABLE_HEADERS } from '../../utils/constants';
 import type { PreArrival } from '../../types/PreArrival';
-import ReceiveModal from './ReceiveModal';
-import ActionsMenu from './ActionsMenu';
-import { formatDateTime } from '../../utils/formatDateTime';
-import ConfirmDialog from '../common/ConfirmDialog';
-import { deletePreArrival } from '../../services/api.services';
 
 interface PreArrivalsTableProps {
   data: PreArrival[];
@@ -16,168 +13,29 @@ interface PreArrivalsTableProps {
 }
 
 const PreArrivalsTable: React.FC<PreArrivalsTableProps> = ({ data, onMarkAsReceive, onDelete, onReceive }) => {
-  const safeData = Array.isArray(data) ? data : [];
-
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedItem, setSelectedItem] = useState<PreArrival | null>(null);
-
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const [selectedRowItem, setSelectedRowItem] = useState<PreArrival | null>(null);
-
-  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
-  const [itemToDelete, setItemToDelete] = useState<PreArrival | null>(null);
-  const [deleteLoading, setDeleteLoading] = useState(false);
-
-  useEffect(() => {
-    if (selectedItem) {
-      const updatedItem = data.find(item => item.id === selectedItem.id);
-      if (updatedItem) {
-        setSelectedItem(updatedItem);
-      }
-    }
-  }, [data, selectedItem]);
-
-  const handleEyeClick = (item: PreArrival) => {
-    setSelectedItem(item);
-    setIsModalOpen(true);
-  };
-
-  const handleDeleteClick = (item: PreArrival) => {
-    setAnchorEl(null);
-    setSelectedRowItem(null);
-    setItemToDelete(item);
-    setIsConfirmOpen(true);
-  };
-
-  const handleConfirmDelete = async () => {
-    if (!itemToDelete) return;
-    try {
-      setDeleteLoading(true);
-      await deletePreArrival(itemToDelete.id);
-      onDelete(itemToDelete)
-    } catch (err) {
-      console.error("Failed to delete pre-arrival:", err);
-    } finally {
-      setDeleteLoading(false);
-      setIsConfirmOpen(false);
-      setItemToDelete(null);
-    }
-  };
-
-  const handleCancelDelete = () => {
-    setIsConfirmOpen(false);
-    setItemToDelete(null);
-  };
-
-  const handleCloseModal = () => {
-    setIsModalOpen(false);
-    setSelectedItem(null);
-  };
-
-  const handleThreeDotsClick = (event: React.MouseEvent<HTMLElement>, item: PreArrival) => {
-    setAnchorEl(event.currentTarget);
-    setSelectedRowItem(item);
-  };
-
-  const handleCloseMenu = () => {
-    setAnchorEl(null);
-    setSelectedRowItem(null);
-  };
-
   return (
-    <>
-      <Paper sx={{ width: '100%', overflow: 'hidden' }}>
-        <TableContainer>
-          <Table>
-            <TableHead>
-                <TableRow sx={{ bgcolor: '#f8fafc' }}>
-                  <TableCell sx={{ fontWeight: 600, color: '#374151', paddingY: "10px" }}>OTP / Tracking No</TableCell>
-                  <TableCell sx={{ fontWeight: 600, color: '#374151', paddingY: "10px" }}>Customer</TableCell>
-                  <TableCell sx={{ fontWeight: 600, color: '#374151', paddingY: "10px" }}>ETA</TableCell>
-                  <TableCell sx={{ fontWeight: 600, color: '#374151', paddingY: "10px" }}>Created At</TableCell>
-                  <TableCell sx={{ fontWeight: 600, color: '#374151', paddingY: "10px" }}>Status</TableCell>
-                  <TableCell sx={{ fontWeight: 600, color: '#374151', paddingY: "10px" }}>Actions</TableCell>
-                </TableRow>
-            </TableHead>
-            <TableBody>
-              {safeData.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={6} sx={{ textAlign: 'center', py: 4 }}>
-                    <Typography variant="body2" color="text.secondary">
-                      No pre-arrivals found
-                    </Typography>
+    <Paper sx={{ width: '100%', overflow: 'hidden' }}>
+      <TableContainer>
+        <Table>
+          <TableHead>
+              <TableRow sx={{ bgcolor: '#f8fafc' }}>
+                {PRE_ARRIVALS_TABLE_HEADERS.map((header) => (
+                  <TableCell key={header} sx={{ fontWeight: 600, color: '#374151', paddingY: "10px" }}>
+                    {header}
                   </TableCell>
-                </TableRow>
-              ) : (
-                safeData.map((row) => (
-                  <TableRow key={row.id} sx={{ '&:hover': { bgcolor: '#f9fafb' } }}>
-                    <TableCell sx={{ paddingY: "10px" }}>
-                      <Box>
-                        <Typography variant="body2" sx={{ fontWeight: 600, color: '#1f2937' }}>{row.otp}</Typography>
-                        {row.tracking_no && (<Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, }}>{row.tracking_no}</Typography>)}
-                      </Box>
-                    </TableCell>
-                    <TableCell sx={{ paddingY: "10px" }}>
-                      <Box>
-                        <Typography variant="body2" sx={{ fontWeight: 600, color: '#0e0e0eba' }}>{row.user}</Typography>
-                        <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, color: '#595959ba' }}>{row.suite}</Typography>
-                      </Box>
-                    </TableCell>
-                    <TableCell sx={{ paddingY: "10px" }}>
-                      <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 600 }}>{row.estimate_arrival_time}</Typography>
-                    </TableCell>
-                    <TableCell sx={{ paddingY: "10px" }}>
-                      <Box>
-                        <Typography variant="body2" sx={{ fontWeight: 600, color: '#696e74' }}>{formatDateTime(row.created_at)}</Typography>
-                      </Box>
-                    </TableCell>
-                    <TableCell sx={{ paddingY: "10px" }}>
-                      <Chip label={row.status.charAt(0).toUpperCase() + row.status.slice(1).toLowerCase()} size="small" sx={{ bgcolor: row.status.toLowerCase() === 'received' ? '#dcfce7' : '#fef3c7', color: row.status.toLowerCase() === 'received' ? '#166534' : '#92400e', fontWeight: 600, fontSize: '0.75rem' }} />
-                    </TableCell>
-                    <TableCell sx={{ paddingY: "10px" }}>
-                      <Box sx={{ display: 'flex', gap: 1 }}>
-                        <IconButton size="small" sx={{ color: '#64748b' }} onClick={() => handleEyeClick(row)}>
-                          <VisibilityIcon fontSize="small" />
-                        </IconButton>
-                        <IconButton size="small" sx={{ color: '#64748b' }} onClick={(e) => handleThreeDotsClick(e, row)}>
-                          <MoreVertIcon fontSize="small" />
-                        </IconButton>
-                      </Box>
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Paper>
+                ))}
+              </TableRow>
+          </TableHead>
 
-      <ReceiveModal
-        isOpen={isModalOpen}
-        onClose={handleCloseModal}
-        selectedItem={selectedItem}
-        onReceive={() => selectedItem ? onReceive(selectedItem) : Promise.reject('No item selected')}
-      />
-
-      <ActionsMenu
-        anchorEl={anchorEl}
-        onClose={handleCloseMenu}
-        selectedRowItem={selectedRowItem}
-        onMarkAsReceive={() => selectedRowItem ? onMarkAsReceive(selectedRowItem) : Promise.resolve()}
-        onDelete={() => selectedRowItem && handleDeleteClick(selectedRowItem)}
-      />
-
-      <ConfirmDialog
-        open={isConfirmOpen}
-        title="Delete Pre-Arrival"
-        message="Are you sure you want to delete this pre-arrival? This action cannot be undone."
-        confirmText="Delete"
-        cancelText="Cancel"
-        onConfirm={handleConfirmDelete}
-        onClose={handleCancelDelete}
-        isLoading={deleteLoading}
-      />
-    </>
+          <PreArrivalsTableBody 
+            data={data}
+            onMarkAsReceive={onMarkAsReceive}
+            onDelete={onDelete}
+            onReceive={onReceive}
+          />
+        </Table>
+      </TableContainer>
+    </Paper>
   );
 };
 

--- a/frontend/admin/src/components/PreArrivals/PreArrivalsTableBody.tsx
+++ b/frontend/admin/src/components/PreArrivals/PreArrivalsTableBody.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Typography, TableBody, TableCell, TableRow, Chip, IconButton } from '@mui/material';
+import { Visibility as VisibilityIcon, MoreVert as MoreVertIcon } from '@mui/icons-material';
+
+import { deletePreArrival } from '../../services/api.services';
+import ConfirmDialog from '../common/ConfirmDialog';
+import ReceiveModal from './ReceiveModal';
+import ActionsMenu from './ActionsMenu';
+import { formatDateTime } from '../../utils/formatDateTime';
+import type { PreArrival } from '../../types/PreArrival';
+
+interface PreArrivalsTableBodyProps {
+  data: PreArrival[];
+  onMarkAsReceive: (item: PreArrival) => Promise<void>;
+  onDelete: (item: PreArrival) => void;
+  onReceive: (item: PreArrival) => Promise<void>;
+}
+
+const PreArrivalsTableBody: React.FC<PreArrivalsTableBodyProps> = ({ 
+  data, 
+  onMarkAsReceive, 
+  onDelete, 
+  onReceive 
+}) => {
+  const safeData = Array.isArray(data) ? data : [];
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedItem, setSelectedItem] = useState<PreArrival | null>(null);
+
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [selectedRowItem, setSelectedRowItem] = useState<PreArrival | null>(null);
+
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [itemToDelete, setItemToDelete] = useState<PreArrival | null>(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+
+  useEffect(() => {
+    if (selectedItem) {
+      const updatedItem = data.find(item => item.id === selectedItem.id);
+      if (updatedItem) {
+        setSelectedItem(updatedItem);
+      }
+    }
+  }, [data, selectedItem]);
+
+  const handleEyeClick = (item: PreArrival) => {
+    setSelectedItem(item);
+    setIsModalOpen(true);
+  };
+
+  const handleDeleteClick = (item: PreArrival) => {
+    setAnchorEl(null);
+    setSelectedRowItem(null);
+    setItemToDelete(item);
+    setIsConfirmOpen(true);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!itemToDelete) return;
+    try {
+      setDeleteLoading(true);
+      await deletePreArrival(itemToDelete.id);
+      onDelete(itemToDelete);
+    } catch (err) {
+      console.error("Failed to delete pre-arrival:", err);
+    } finally {
+      setDeleteLoading(false);
+      setIsConfirmOpen(false);
+      setItemToDelete(null);
+    }
+  };
+
+  const handleCancelDelete = () => {
+    setIsConfirmOpen(false);
+    setItemToDelete(null);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setSelectedItem(null);
+  };
+
+  const handleThreeDotsClick = (event: React.MouseEvent<HTMLElement>, item: PreArrival) => {
+    setAnchorEl(event.currentTarget);
+    setSelectedRowItem(item);
+  };
+
+  const handleCloseMenu = () => {
+    setAnchorEl(null);
+    setSelectedRowItem(null);
+  };
+
+  return (
+    <>
+      <TableBody>
+        {safeData.length === 0 ? (
+          <TableRow>
+            <TableCell colSpan={6} sx={{ textAlign: 'center', py: 4 }}>
+              <Typography variant="body2" color="text.secondary">
+                No pre-arrivals found
+              </Typography>
+            </TableCell>
+          </TableRow>
+        ) : (
+          safeData.map((row) => (
+            <TableRow key={row.id} sx={{ '&:hover': { bgcolor: '#f9fafb' } }}>
+              <TableCell sx={{ paddingY: "10px" }}>
+                <Box>
+                  <Typography variant="body2" sx={{ fontWeight: 600, color: '#1f2937' }}>{row.otp}</Typography>
+                  {row.tracking_no && (<Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, }}>{row.tracking_no}</Typography>)}
+                </Box>
+              </TableCell>
+              <TableCell sx={{ paddingY: "10px" }}>
+                <Box>
+                  <Typography variant="body2" sx={{ fontWeight: 600, color: '#0e0e0eba' }}>{row.user}</Typography>
+                  <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, color: '#595959ba' }}>{row.suite}</Typography>
+                </Box>
+              </TableCell>
+              <TableCell sx={{ paddingY: "10px" }}>
+                <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 600 }}>{row.estimate_arrival_time}</Typography>
+              </TableCell>
+              <TableCell sx={{ paddingY: "10px" }}>
+                <Box>
+                  <Typography variant="body2" sx={{ fontWeight: 600, color: '#696e74' }}>{formatDateTime(row.created_at)}</Typography>
+                </Box>
+              </TableCell>
+              <TableCell sx={{ paddingY: "10px" }}>
+                <Chip label={row.status.charAt(0).toUpperCase() + row.status.slice(1).toLowerCase()} size="small" sx={{ bgcolor: row.status.toLowerCase() === 'received' ? '#dcfce7' : '#fef3c7', color: row.status.toLowerCase() === 'received' ? '#166534' : '#92400e', fontWeight: 600, fontSize: '0.75rem' }} />
+              </TableCell>
+              <TableCell sx={{ paddingY: "10px" }}>
+                <Box sx={{ display: 'flex', gap: 1 }}>
+                  <IconButton size="small" sx={{ color: '#64748b' }} onClick={() => handleEyeClick(row)}>
+                    <VisibilityIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" sx={{ color: '#64748b' }} onClick={(e) => handleThreeDotsClick(e, row)}>
+                    <MoreVertIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              </TableCell>
+            </TableRow>
+          ))
+        )}
+      </TableBody>
+
+      <ReceiveModal
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        selectedItem={selectedItem}
+        onReceive={() => selectedItem ? onReceive(selectedItem) : Promise.reject('No item selected')}
+      />
+
+      <ActionsMenu
+        anchorEl={anchorEl}
+        onClose={handleCloseMenu}
+        selectedRowItem={selectedRowItem}
+        onMarkAsReceive={() => selectedRowItem ? onMarkAsReceive(selectedRowItem) : Promise.resolve()}
+        onDelete={() => selectedRowItem && handleDeleteClick(selectedRowItem)}
+      />
+
+      <ConfirmDialog
+        open={isConfirmOpen}
+        title="Delete Pre-Arrival"
+        message="Are you sure you want to delete this pre-arrival? This action cannot be undone."
+        confirmText="Delete"
+        cancelText="Cancel"
+        onConfirm={handleConfirmDelete}
+        onClose={handleCancelDelete}
+        isLoading={deleteLoading}
+      />
+    </>
+  );
+};
+
+export default PreArrivalsTableBody;

--- a/frontend/admin/src/components/PreArrivals/ReceiveModal.tsx
+++ b/frontend/admin/src/components/PreArrivals/ReceiveModal.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
-import { Box, Typography, Modal, IconButton, Button, Chip, CircularProgress } from '@mui/material';
-import { Close as CloseIcon } from '@mui/icons-material';
+import { Box, Modal } from '@mui/material';
+
+import ReceiveModalHeader from './ReceiveModalHeader';
+import ReceiveModalContent from './ReceiveModalContent';
+import ReceiveModalActions from './ReceiveModalActions';
 import type { PreArrival } from '../../types/PreArrival';
 
 interface ReceiveModalProps {
@@ -36,7 +39,7 @@ const ReceiveModal: React.FC<ReceiveModalProps> = ({
       open={isOpen}
       onClose={() => {
         if (!isReceiving) {
-            onClose();
+          onClose();
         }
       }} 
       aria-labelledby="customer-details-modal"
@@ -53,96 +56,15 @@ const ReceiveModal: React.FC<ReceiveModalProps> = ({
         boxShadow: 24,
         p: 4,
       }}>
-        {/* Modal Header */}
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-          <Typography variant="h6" component="h2" sx={{ fontWeight: 600 }}>
-            Receive
-          </Typography>
-          <IconButton onClick={onClose} size="small">
-            <CloseIcon />
-          </IconButton>
-        </Box>
+        <ReceiveModalHeader onClose={onClose} />
 
-        {/* Modal Content */}
-        {selectedItem && (
-          <Box sx={{ mb: 2 }}>
-            <Box sx={{ mb: 1.5 }}>
-              <Typography variant="body2" sx={{ mb: 0.5, color: '#6b7280', fontSize: '0.875rem', fontWeight: 600 }}>
-                Customer
-              </Typography>
-              <Typography variant="body1" sx={{ fontWeight: 700, fontSize: '1rem', color: '#111827' }}>
-                {selectedItem.user} ({selectedItem.suite})
-              </Typography>
-            </Box>
+        <ReceiveModalContent selectedItem={selectedItem} />
 
-            <Box sx={{ mb: 1.5 }}>
-              <Typography variant="body2" sx={{ mb: 0.5, color: '#6b7280', fontSize: '0.875rem', fontWeight: 600 }}>
-                OTP
-              </Typography>
-              <Typography variant="body1" sx={{ fontWeight: 700, fontSize: '1rem', color: '#111827' }}>
-                {selectedItem.otp}
-              </Typography>
-            </Box>
-
-            <Box sx={{ mb: 1.5 }}>
-              <Typography variant="body2" sx={{ mb: 0.5, color: '#6b7280', fontSize: '0.875rem', fontWeight: 600 }}>
-                Tracking / Order No.
-              </Typography>
-              <Typography variant="body1" sx={{ fontWeight: 700, fontSize: '1rem', color: '#111827' }}>
-                {selectedItem.tracking_no || 'N/A'}
-              </Typography>
-            </Box>
-
-            <Box sx={{ mb: 1.5 }}>
-              <Typography variant="body2" sx={{ mb: 0.5, color: '#6b7280', fontSize: '0.875rem', fontWeight: 600 }}>
-                ETA
-              </Typography>
-              <Typography variant="body1" sx={{ fontWeight: 700, fontSize: '1rem', color: '#111827' }}>
-                {selectedItem.estimate_arrival_time}
-              </Typography>
-            </Box>
-
-            <Box sx={{ mb: 1.5 }}>
-              <Typography variant="body2" sx={{ mb: 0.5, color: '#6b7280', fontSize: '0.875rem', fontWeight: 600 }}>
-                Status
-              </Typography>
-              <Chip
-                label={selectedItem.status.charAt(0).toUpperCase() + selectedItem.status.slice(1).toLowerCase()}
-                size="small"
-                sx={{
-                  bgcolor: selectedItem.status.toLowerCase() === 'received' ? '#dcfce7' : '#fef3c7',
-                  color: selectedItem.status.toLowerCase() === 'received' ? '#166534' : '#92400e',
-                  fontWeight: 700,
-                  fontSize: '0.75rem',
-                  height: '24px',
-                  borderRadius: '5px'
-                }}
-              />
-            </Box>
-
-            <Box sx={{ mb: 1.5 }}>
-              <Typography variant="body2" sx={{ mb: 0.5, color: '#6b7280', fontSize: '0.875rem', fontWeight: 600 }}>
-                Package Details
-              </Typography>
-              <Typography variant="body1" sx={{ fontWeight: 700, fontSize: '1rem', color: '#111827' }}>
-                {selectedItem.details || 'N/A'}
-              </Typography>
-            </Box>
-          </Box>
-        )}
-
-        {/* Modal Actions */}
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleReceiveClick}
-            disabled={selectedItem?.status.toLowerCase() === 'received' || isReceiving}
-            sx={{ minWidth: 100, fontWeight: 600, bgcolor: '#8b5cf6','&:hover': { bgcolor: '#7c3aed'}}}
-          >
-            {isReceiving ? <CircularProgress size={24} color="inherit" /> : 'Receive'}
-          </Button>
-        </Box>
+        <ReceiveModalActions
+          selectedItem={selectedItem}
+          isReceiving={isReceiving}
+          onReceiveClick={handleReceiveClick}
+        />
       </Box>
     </Modal>
   );

--- a/frontend/admin/src/components/PreArrivals/ReceiveModalActions.tsx
+++ b/frontend/admin/src/components/PreArrivals/ReceiveModalActions.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Box, Button, CircularProgress } from '@mui/material';
+
+import type { PreArrival } from '../../types/PreArrival';
+
+interface ReceiveModalActionsProps {
+  selectedItem: PreArrival;
+  isReceiving: boolean;
+  onReceiveClick: () => void;
+}
+
+const ReceiveModalActions: React.FC<ReceiveModalActionsProps> = ({
+  selectedItem,
+  isReceiving,
+  onReceiveClick
+}) => {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={onReceiveClick}
+        disabled={selectedItem.status.toLowerCase() === 'received' || isReceiving}
+        sx={{
+          minWidth: 100,
+          fontWeight: 600,
+          bgcolor: '#8b5cf6',
+          '&:hover': { bgcolor: '#7c3aed' }
+        }}
+      >
+        {isReceiving ? <CircularProgress size={24} color="inherit" /> : 'Receive'}
+      </Button>
+    </Box>
+  );
+};
+
+export default ReceiveModalActions;

--- a/frontend/admin/src/components/PreArrivals/ReceiveModalContent.tsx
+++ b/frontend/admin/src/components/PreArrivals/ReceiveModalContent.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Box, Typography, Chip } from '@mui/material';
+
+import type { PreArrival } from '../../types/PreArrival';
+
+interface ReceiveModalContentProps {
+  selectedItem: PreArrival;
+}
+
+const ReceiveModalContent: React.FC<ReceiveModalContentProps> = ({ selectedItem }) => {
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Box sx={{ mb: 1.5 }}>
+        <Typography variant="body2" sx={{ mb: 0.5, color: '#6b7280', fontSize: '0.875rem', fontWeight: 600 }}>
+          Customer
+        </Typography>
+        <Typography variant="body1" sx={{ fontWeight: 700, fontSize: '1rem', color: '#111827' }}>
+          {selectedItem.user} ({selectedItem.suite})
+        </Typography>
+      </Box>
+
+      <Box sx={{ mb: 1.5 }}>
+        <Typography variant="body2" sx={{ mb: 0.5, color: '#6b7280', fontSize: '0.875rem', fontWeight: 600 }}>
+          OTP
+        </Typography>
+        <Typography variant="body1" sx={{ fontWeight: 700, fontSize: '1rem', color: '#111827' }}>
+          {selectedItem.otp}
+        </Typography>
+      </Box>
+
+      <Box sx={{ mb: 1.5 }}>
+        <Typography variant="body2" sx={{ mb: 0.5, color: '#6b7280', fontSize: '0.875rem', fontWeight: 600 }}>
+          Tracking / Order No.
+        </Typography>
+        <Typography variant="body1" sx={{ fontWeight: 700, fontSize: '1rem', color: '#111827' }}>
+          {selectedItem.tracking_no || 'N/A'}
+        </Typography>
+      </Box>
+
+      <Box sx={{ mb: 1.5 }}>
+        <Typography variant="body2" sx={{ mb: 0.5, color: '#6b7280', fontSize: '0.875rem', fontWeight: 600 }}>
+          ETA
+        </Typography>
+        <Typography variant="body1" sx={{ fontWeight: 700, fontSize: '1rem', color: '#111827' }}>
+          {selectedItem.estimate_arrival_time}
+        </Typography>
+      </Box>
+
+      <Box sx={{ mb: 1.5 }}>
+        <Typography variant="body2" sx={{ mb: 0.5, color: '#6b7280', fontSize: '0.875rem', fontWeight: 600 }}>
+          Status
+        </Typography>
+        <Chip
+          label={selectedItem.status.charAt(0).toUpperCase() + selectedItem.status.slice(1).toLowerCase()}
+          size="small"
+          sx={{
+            bgcolor: selectedItem.status.toLowerCase() === 'received' ? '#dcfce7' : '#fef3c7',
+            color: selectedItem.status.toLowerCase() === 'received' ? '#166534' : '#92400e',
+            fontWeight: 700,
+            fontSize: '0.75rem',
+            height: '24px',
+            borderRadius: '5px'
+          }}
+        />
+      </Box>
+
+      <Box sx={{ mb: 1.5 }}>
+        <Typography variant="body2" sx={{ mb: 0.5, color: '#6b7280', fontSize: '0.875rem', fontWeight: 600 }}>
+          Package Details
+        </Typography>
+        <Typography variant="body1" sx={{ fontWeight: 700, fontSize: '1rem', color: '#111827' }}>
+          {selectedItem.details || 'N/A'}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default ReceiveModalContent;

--- a/frontend/admin/src/components/PreArrivals/ReceiveModalHeader.tsx
+++ b/frontend/admin/src/components/PreArrivals/ReceiveModalHeader.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Box, Typography, IconButton } from '@mui/material';
+import { Close as CloseIcon } from '@mui/icons-material';
+
+interface ReceiveModalHeaderProps {
+  onClose: () => void;
+}
+
+const ReceiveModalHeader: React.FC<ReceiveModalHeaderProps> = ({ onClose }) => {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+      <Typography variant="h6" component="h2" sx={{ fontWeight: 600 }}>
+        Receive
+      </Typography>
+      <IconButton onClick={onClose} size="small">
+        <CloseIcon />
+      </IconButton>
+    </Box>
+  );
+};
+
+export default ReceiveModalHeader;

--- a/frontend/admin/src/components/ShipmentExport/AddNewBoxButton.tsx
+++ b/frontend/admin/src/components/ShipmentExport/AddNewBoxButton.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from "react";
+import { Button, CircularProgress } from "@mui/material";
+import { Add as AddIcon } from "@mui/icons-material";
+import { createShipmentExportBox } from "../../services/api.services";
+
+interface AddNewBoxButtonProps {
+  shipmentId: string;
+  onBoxAdded: () => void;
+  isDeparted: boolean;
+  hasBoxes: boolean;
+}
+
+const AddNewBoxButton: React.FC<AddNewBoxButtonProps> = ({
+  shipmentId,
+  onBoxAdded,
+  isDeparted,
+  hasBoxes,
+}) => {
+  const [isAdding, setIsAdding] = useState(false);
+
+  const handleAddBox = async () => {
+    if (isDeparted) return;
+
+    setIsAdding(true);
+    try {
+      await createShipmentExportBox(shipmentId, {
+        length_cm: 0,
+        breadth_cm: 0,
+        height_cm: 0,
+        volumetric_weight: 0,
+        mass_weight: 0,
+      });
+
+      onBoxAdded();
+    } catch (error) {
+      console.error("Failed to create box:", error);
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  return (
+    <Button
+      variant="contained"
+      disabled={isAdding || isDeparted}
+      startIcon={
+        isAdding ? (
+          <CircularProgress size={20} color="inherit" />
+        ) : (
+          <AddIcon />
+        )
+      }
+      sx={{
+        textTransform: "none",
+        borderRadius: 2,
+        boxShadow: "none",
+        alignSelf: "flex-start",
+        mt: hasBoxes ? 2 : 0,
+      }}
+      onClick={handleAddBox}
+    >
+      {isAdding ? "Adding..." : "Add New Box"}
+    </Button>
+  );
+};
+
+export default AddNewBoxButton;

--- a/frontend/admin/src/components/ShipmentExport/BoxCard.tsx
+++ b/frontend/admin/src/components/ShipmentExport/BoxCard.tsx
@@ -1,17 +1,10 @@
 import React from "react";
 import { Box, Card, CircularProgress, IconButton, Typography } from "@mui/material";
 import { Edit as EditIcon, DeleteOutline as DeleteIcon } from "@mui/icons-material";
+import type { BoxItem } from "../../types";
 
 interface BoxCardProps {
-  box: {
-    id: string;
-    label?: string;
-    length_cm: number;
-    breadth_cm: number;
-    height_cm: number;
-    volumetric_weight?: number;
-    mass_weight?: number;
-  };
+  box: BoxItem;
   index: number;
   total: number;
   onEdit: (boxId: string, displayLabel: string) => void;

--- a/frontend/admin/src/components/ShipmentExport/BoxShipmentsList.tsx
+++ b/frontend/admin/src/components/ShipmentExport/BoxShipmentsList.tsx
@@ -1,32 +1,16 @@
 import React from "react";
 import {
   Box,
-  CircularProgress,
-  IconButton,
   Table,
-  TableBody,
   TableCell,
   TableHead,
   TableRow,
   Typography,
 } from "@mui/material";
-import { Delete as DeleteIcon } from "@mui/icons-material";
-import { removeShipmentFromBox } from "../../services/api.services";
-import { formatDateTime } from "../../utils/formatDateTime";
 
-export interface Shipment {
-  id: string;
-  tracking_no: string;
-  shipment_no: string;
-  courier: string;
-  customer: string;
-  customerCode: string;
-  updated_at: string;
-  time: string;
-  user: {
-    name: string;
-  }
-}
+import BoxShipmentsTableBody from "./BoxShipmentsTableBody";
+import { BOX_SHIPMENTS_TABLE_HEADERS } from "../../utils/constants";
+import type { Shipment } from "../../types";
 
 interface BoxShipmentsListProps {
   boxId: string;
@@ -49,17 +33,6 @@ const BoxShipmentsList: React.FC<BoxShipmentsListProps> = ({
   isLoading,
   isDeparted,
 }) => {
-
-  const handleDeleteShipment = async (shipmentId: string) => {
-    if (!boxId || isDeparted) return;
-    try {
-      await removeShipmentFromBox(boxId, shipmentId);
-      refreshShipments();
-    } catch (error) {
-      console.error("Failed to delete shipment from box:", error);
-    }
-  };
-
   const displayLabel = boxLabel 
     ? boxLabel 
     : totalBoxes === 1 
@@ -97,67 +70,21 @@ const BoxShipmentsList: React.FC<BoxShipmentsListProps> = ({
                 },
               }}
             >
-              <TableCell>Shipment No.</TableCell>
-              <TableCell>Tracking No.</TableCell>
-              <TableCell>Customer</TableCell>
-              <TableCell>Date</TableCell>
-              <TableCell align="center" />
+              {BOX_SHIPMENTS_TABLE_HEADERS.map((header, index) => (
+                <TableCell key={index} align={header.align}>
+                  {header.label}
+                </TableCell>
+              ))}
             </TableRow>
           </TableHead>
 
-          <TableBody>
-            {isLoading ? (
-              <TableRow>
-                <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
-                  <CircularProgress size={24} />
-                  <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                    Loading shipments...
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            ) : shipments.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={5} align="center" sx={{ py: 3 }}>
-                  <Typography variant="body2" color="text.secondary">
-                    No shipments found
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            ) : (
-              shipments.map((pkg) => (
-                <TableRow key={pkg.id}>
-                  <TableCell>{pkg.shipment_no}</TableCell>
-
-                  <TableCell>
-                    <Typography fontWeight={500}>{pkg.tracking_no}</Typography>
-                  </TableCell>
-
-                  <TableCell>
-                    <Typography fontWeight={500}>{pkg.user.name}</Typography>
-                  </TableCell>
-
-                  <TableCell>
-                    <Typography fontWeight={500}>{formatDateTime(pkg.updated_at)}</Typography>
-                  </TableCell>
-
-                  <TableCell align="center">
-                    <IconButton
-                      sx={{
-                        bgcolor: "#f87171",
-                        color: "white",
-                        "&:hover": { bgcolor: "#ef4444" },
-                      }}
-                      size="small"
-                      onClick={() => handleDeleteShipment(pkg.id)}
-                      disabled={isDeparted}
-                    >
-                      <DeleteIcon fontSize="small" />
-                    </IconButton>
-                  </TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
+          <BoxShipmentsTableBody
+            boxId={boxId}
+            shipments={shipments}
+            isLoading={isLoading}
+            isDeparted={isDeparted}
+            refreshShipments={refreshShipments}
+          />
         </Table>
       </Box>
     </Box>

--- a/frontend/admin/src/components/ShipmentExport/BoxShipmentsTableBody.tsx
+++ b/frontend/admin/src/components/ShipmentExport/BoxShipmentsTableBody.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import {
+  CircularProgress,
+  IconButton,
+  TableBody,
+  TableCell,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { Delete as DeleteIcon } from "@mui/icons-material";
+
+import { removeShipmentFromBox } from "../../services/api.services";
+import { formatDateTime } from "../../utils/formatDateTime";
+import type { Shipment } from "../../types";
+
+interface BoxShipmentsTableBodyProps {
+  boxId: string;
+  shipments: Shipment[];
+  isLoading: boolean;
+  isDeparted: boolean;
+  refreshShipments: () => void;
+}
+
+const BoxShipmentsTableBody: React.FC<BoxShipmentsTableBodyProps> = ({
+  boxId,
+  shipments,
+  isLoading,
+  isDeparted,
+  refreshShipments,
+}) => {
+  const handleDeleteShipment = async (shipmentId: string) => {
+    if (!boxId || isDeparted) return;
+
+    try {
+      await removeShipmentFromBox(boxId, shipmentId);
+      refreshShipments();
+    } catch (error) {
+      console.error("Failed to delete shipment from box:", error);
+    }
+  };
+
+  return (
+    <TableBody>
+      {isLoading ? (
+        <TableRow>
+          <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+            <CircularProgress size={24} />
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              Loading shipments...
+            </Typography>
+          </TableCell>
+        </TableRow>
+      ) : shipments.length === 0 ? (
+        <TableRow>
+          <TableCell colSpan={5} align="center" sx={{ py: 3 }}>
+            <Typography variant="body2" color="text.secondary">
+              No shipments found
+            </Typography>
+          </TableCell>
+        </TableRow>
+      ) : (
+        shipments.map((pkg) => (
+          <TableRow key={pkg.id}>
+            <TableCell>{pkg.shipment_no}</TableCell>
+
+            <TableCell>
+              <Typography fontWeight={500}>
+                {pkg.tracking_no}
+              </Typography>
+            </TableCell>
+
+            <TableCell>
+              <Typography fontWeight={500}>
+                {pkg.user.name}
+              </Typography>
+            </TableCell>
+
+            <TableCell>
+              <Typography fontWeight={500}>
+                {formatDateTime(pkg.updated_at)}
+              </Typography>
+            </TableCell>
+
+            <TableCell align="center">
+              <IconButton
+                sx={{
+                  bgcolor: "#f87171",
+                  color: "white",
+                  "&:hover": { bgcolor: "#ef4444" },
+                }}
+                size="small"
+                onClick={() => handleDeleteShipment(pkg.id)}
+                disabled={isDeparted}
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </TableCell>
+          </TableRow>
+        ))
+      )}
+    </TableBody>
+  );
+};
+
+export default BoxShipmentsTableBody;

--- a/frontend/admin/src/components/ShipmentExport/BoxesSection.tsx
+++ b/frontend/admin/src/components/ShipmentExport/BoxesSection.tsx
@@ -1,34 +1,13 @@
 import React, { useState } from "react";
-import { Box, Button, CircularProgress, Typography } from "@mui/material";
-import { Add as AddIcon } from "@mui/icons-material";
-import {
-  createShipmentExportBox,
-  deleteShipmentExportBox,
-  updateShipmentExportBox,
-} from "../../services/api.services";
+import { Box, Typography } from "@mui/material";
+
+import { deleteShipmentExportBox, updateShipmentExportBox } from "../../services/api.services";
 import BoxCard from "./BoxCard";
-import BoxShipmentsList, { type Shipment } from "./BoxShipmentsList";
+import BoxShipmentsList from "./BoxShipmentsList";
 import Modal from "../common/Modal";
 import BoxDetailsForm from "./BoxDetailsForm";
-
-interface BoxItem {
-  id: string;
-  label: string;
-  length_cm: number;
-  breadth_cm: number;
-  height_cm: number;
-  volumetric_weight?: number;
-  mass_weight?: number;
-}
-
-interface BoxFormValues {
-  label: string;
-  length: string;
-  breadth: string;
-  height: string;
-  volumetricWeight: string;
-  massWeight: string;
-}
+import AddNewBoxButton from "./AddNewBoxButton";
+import type { BoxFormValues, BoxItem, Shipment } from "../../types";
 
 interface BoxesSectionProps {
   boxes: BoxItem[];
@@ -54,12 +33,12 @@ const BoxesSection: React.FC<BoxesSectionProps> = ({
   status,
 }) => {
   const [open, setOpen] = useState(false);
-  const [isAddingBox, setIsAddingBox] = useState(false);
   const [deletingBoxId, setDeletingBoxId] = useState<string | null>(null);
   const [editingBoxLabel, setEditingBoxLabel] = useState<string | null>(null);
 
   const isDeparted = status === "SHIPMENTS DEPARTED";
-  const selectedBoxData = boxes.find((b) => b.id === selectedBoxId);
+  const selectedBoxData = boxes.find((box) => box.id === selectedBoxId);
+  const selectedBoxIndex = boxes.findIndex((box) => box.id === selectedBoxId);
 
   const handleEditClick = (boxId: string, displayLabel: string) => {
     if (isDeparted) return;
@@ -88,35 +67,14 @@ const BoxesSection: React.FC<BoxesSectionProps> = ({
       });
       
       onBoxAdded();
-      setOpen(false);
-      setSelectedBoxId(null);
-      setEditingBoxLabel(null);
+      handleClose();
     } catch (error) {
       console.error("Failed to update box:", error);
     }
   };
 
-  const handleAddBox = async () => {
-    if (isDeparted) return; // Disabled when departed
-    setIsAddingBox(true);
-    try {
-      await createShipmentExportBox(shipmentId, {
-        length_cm: 0,
-        breadth_cm: 0,
-        height_cm: 0,
-        volumetric_weight: 0,
-        mass_weight: 0,
-      });
-      onBoxAdded();
-    } catch (error) {
-      console.error("Failed to create box:", error);
-    } finally {
-      setIsAddingBox(false);
-    }
-  };
-
   const handleDelete = async (boxId: string) => {
-    if (isDeparted) return; // Disabled when departed
+    if (isDeparted) return;
     setDeletingBoxId(boxId);
     try {
       await deleteShipmentExportBox(boxId);
@@ -150,27 +108,12 @@ const BoxesSection: React.FC<BoxesSectionProps> = ({
             />
           ))}
 
-          <Button
-            variant="contained"
-            disabled={isAddingBox || isDeparted}
-            startIcon={
-              isAddingBox ? (
-                <CircularProgress size={20} color="inherit" />
-              ) : (
-                <AddIcon />
-              )
-            }
-            sx={{
-              textTransform: "none",
-              borderRadius: 2,
-              boxShadow: "none",
-              alignSelf: "flex-start",
-              mt: boxes.length > 0 ? 2 : 0, 
-            }}
-            onClick={handleAddBox}
-          >
-            {isAddingBox ? "Adding..." : "Add New Box"}
-          </Button>
+          <AddNewBoxButton
+            shipmentId={shipmentId}
+            onBoxAdded={onBoxAdded}
+            isDeparted={isDeparted}
+            hasBoxes={boxes.length > 0}
+          />
         </Box>
 
         <Box sx={{ flex: 1, minWidth: 0 }}>
@@ -178,8 +121,8 @@ const BoxesSection: React.FC<BoxesSectionProps> = ({
             <BoxShipmentsList
               boxId={selectedBoxId}
               refreshShipments={refreshShipments}
-              boxIndex={boxes.findIndex(b => b.id === selectedBoxId)}
-              boxLabel={boxes.find(b => b.id === selectedBoxId)?.label}
+              boxIndex={selectedBoxIndex}
+              boxLabel={selectedBoxData?.label}
               totalBoxes={boxes.length}
               shipments={shipmentsInSelectedBox}
               isLoading={loadingShipments}

--- a/frontend/admin/src/components/ShipmentExport/MarkExportDepartedButton.tsx
+++ b/frontend/admin/src/components/ShipmentExport/MarkExportDepartedButton.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from "react";
+import { Button, CircularProgress, Box } from "@mui/material";
+import {
+  markShipmentExportDeparted,
+  updateShipmentStatus,
+  getShipmentsByBoxIds,
+} from "../../services/api.services";
+
+interface Shipment {
+  id: string;
+}
+
+interface BoxItem {
+  id: string;
+  shipments?: Shipment[];
+}
+
+interface ShipmentExport {
+  status: string;
+  boxes?: BoxItem[];
+}
+
+interface MarkExportDepartedButtonProps {
+  exportId: string;
+  disabled: boolean;
+  onStatusUpdated: (newStatus: string) => void;
+  onShipmentsRefreshed: (shipments: any[]) => void;
+}
+
+const MarkExportDepartedButton: React.FC<MarkExportDepartedButtonProps> = ({
+  exportId,
+  disabled,
+  onStatusUpdated,
+  onShipmentsRefreshed,
+}) => {
+  const [loading, setLoading] = useState(false);
+
+  const handleMarkDeparted = async () => {
+    try {
+      setLoading(true);
+
+      const updated: ShipmentExport = await markShipmentExportDeparted(exportId);
+      onStatusUpdated(updated.status);
+
+      if (updated.boxes) {
+        const allShipments: Shipment[] = updated.boxes.flatMap(
+          (box) => box.shipments ?? []
+        );
+
+        if (allShipments.length > 0) {
+          await Promise.allSettled(
+            allShipments.map((shipment) =>
+              updateShipmentStatus(shipment.id, "DEPARTED")
+            )
+          );
+        }
+
+        const boxIds = updated.boxes.map((box) => box.id);
+        const refreshedShipments = await getShipmentsByBoxIds(boxIds);
+
+        onShipmentsRefreshed(refreshedShipments);
+      }
+    } catch (err) {
+      console.error("Failed to update to departed", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Button
+      variant="contained"
+      disabled={loading || disabled}
+      onClick={handleMarkDeparted}
+      sx={{
+        bgcolor: "#3b82f6",
+        "&:hover": { bgcolor: "#2563eb" },
+        textTransform: "none",
+      }}
+    >
+      {loading ? (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <CircularProgress size={16} color="inherit" />
+          Updating...
+        </Box>
+      ) : (
+        "Update to Departed"
+      )}
+    </Button>
+  );
+};
+
+export default MarkExportDepartedButton;

--- a/frontend/admin/src/components/ShipmentExport/ShipmentActionsBar.tsx
+++ b/frontend/admin/src/components/ShipmentExport/ShipmentActionsBar.tsx
@@ -1,15 +1,14 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { Box, Button, CircularProgress, InputAdornment, TextField, Typography } from "@mui/material";
+import { Box, InputAdornment, TextField, Typography } from "@mui/material";
 import { Search as SearchIcon } from "@mui/icons-material";
 import { 
   addShipmentToBox,
   getShipmentsByBoxIds,
-  markShipmentExportDeparted,
   searchReadyToShipShipment,
-  updateShipmentStatus,
 } from "../../services/api.services";
 import ExportButton from "./ExportButton";
 import { LoadingEndAdornment } from "../common/LoadingEndAdornment";
+import MarkExportDepartedButton from "./MarkExportDepartedButton";
 
 interface Shipment {
   id: string;
@@ -19,11 +18,6 @@ interface Shipment {
 interface BoxItem {
   id: string;
   shipments?: Shipment[];
-}
-
-interface ShipmentExport {
-  status: string;
-  boxes?: BoxItem[];
 }
 
 interface ShipmentActionsBarProps {
@@ -46,7 +40,6 @@ const ShipmentActionsBar: React.FC<ShipmentActionsBarProps> = ({
   boxes = [],
 }) => {
   const [shipmentNumber, setShipmentNumber] = useState("");
-  const [loading, setLoading] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [allShipments, setAllShipments] = useState<any[]>([]);
@@ -113,33 +106,6 @@ const ShipmentActionsBar: React.FC<ShipmentActionsBarProps> = ({
     }
   };
 
-  const handleUpdateDeparted = async () => {
-    try {
-      setLoading(true);
-      const updated: ShipmentExport = await markShipmentExportDeparted(exportId);
-      onStatusUpdated(updated.status);
-
-      if (updated.boxes) {
-        const allShipments: Shipment[] = updated.boxes.flatMap((box) => box.shipments ?? []);
-        if (allShipments.length > 0) {
-          await Promise.allSettled(
-            allShipments.map((shipment) =>
-              updateShipmentStatus(shipment.id, "DEPARTED")
-            )
-          );
-        }
-
-        const boxIds = updated.boxes.map((box: any) => box.id);
-        const refreshedShipments = await getShipmentsByBoxIds(boxIds);
-        setAllShipments(refreshedShipments);
-      }
-    } catch (err) {
-      console.error("Failed to update to departed", err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
   const handleTrackingChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setShipmentNumber(event.target.value);
     if (error) setError(null);
@@ -197,21 +163,12 @@ const ShipmentActionsBar: React.FC<ShipmentActionsBarProps> = ({
 
       {!isDeparted && (
         <Box sx={{ display: "flex", gap: 2, flexShrink: 0, marginLeft: "auto" }}>
-          <Button
-            variant="contained"
-            disabled={loading || allShipments.length === 0}
-            onClick={handleUpdateDeparted}
-            sx={{ bgcolor: "#3b82f6", "&:hover": { bgcolor: "#2563eb" }, textTransform: "none" }}
-          >
-            {loading ? (
-              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                <CircularProgress size={16} color="inherit" />
-                Updating...
-              </Box>
-            ) : (
-              "Update to Departed"
-            )}
-          </Button>
+          <MarkExportDepartedButton
+            exportId={exportId}
+            disabled={allShipments.length === 0}
+            onStatusUpdated={onStatusUpdated}
+            onShipmentsRefreshed={setAllShipments}
+          />
         </Box>
       )}
     </Box>

--- a/frontend/admin/src/components/ShipmentExport/ShipmentExportTable.tsx
+++ b/frontend/admin/src/components/ShipmentExport/ShipmentExportTable.tsx
@@ -9,9 +9,11 @@ import {
   TablePagination,
 } from '@mui/material';
 import dayjs, { Dayjs } from 'dayjs';
+
 import { getShipmentExports } from '../../services/api.services';
 import ShipmentExportFilters from './ShipmentExportFilters';
 import ShipmentExportTableBody, { type ShipmentExportRow } from './ShipmentExportTableBody';
+import { SHIPMENT_EXPORT_TABLE_HEADERS } from '../../utils/constants';
 
 const ShipmentExportTable: React.FC = () => {
   const [rows, setRows] = useState<ShipmentExportRow[]>([]);
@@ -55,16 +57,6 @@ const ShipmentExportTable: React.FC = () => {
     page * rowsPerPage + rowsPerPage
   );
 
-  const tableHeaders = [
-    "Serial #",
-    "Date",
-    "MAWB",
-    "Count",
-    "Created By",
-    "Status",
-    "Actions",
-  ];
-
   return (
     <>
       <ShipmentExportFilters 
@@ -78,7 +70,7 @@ const ShipmentExportTable: React.FC = () => {
           <Table>
             <TableHead sx={{ bgcolor: '#f8fafc' }}>
               <TableRow>
-                {tableHeaders.map((header, index) => (
+                {SHIPMENT_EXPORT_TABLE_HEADERS.map((header, index) => (
                   <TableCell key={index}>{header}</TableCell>
                 ))}
               </TableRow>

--- a/frontend/admin/src/components/Shipments/Detail/ActionLogs.tsx
+++ b/frontend/admin/src/components/Shipments/Detail/ActionLogs.tsx
@@ -1,37 +1,41 @@
 import { Box, Button, Card, Typography } from '@mui/material';
+import { useShipmentDetail } from '../../../contexts/ShipmentDetailContext';
 
-const ActionLogs = ({ isDiscarded }) => (
+const ActionLogs = () => {
+  const { isDiscarded } = useShipmentDetail();
+
+  return (
     <Box sx={{ mt: 3 }}>
-        <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              mb: 1.5,
-            }}
-        >
-            <Typography
-              variant="h6"
-              fontWeight={600}
-            > 
-              Action Logs 
-            </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 1.5,
+        }}
+      >
+        <Typography
+          variant="h6"
+          fontWeight={600}
+        > 
+          Action Logs 
+        </Typography>
 
-            <Button
-              variant="contained"
-              size="small"
-              disabled={isDiscarded}
-              sx={{
-                textTransform: 'none',
-                bgcolor: isDiscarded ? '#cbd5e1' : undefined,
-                color: isDiscarded ? '#64748b' : undefined,
-                cursor: isDiscarded ? 'not-allowed' : 'pointer',
-                opacity: isDiscarded ? 0.7 : 1,
-              }}
-            >
-              Add
-            </Button>
-        </Box>
+        <Button
+          variant="contained"
+          size="small"
+          disabled={isDiscarded}
+          sx={{
+            textTransform: 'none',
+            bgcolor: isDiscarded ? '#cbd5e1' : undefined,
+            color: isDiscarded ? '#64748b' : undefined,
+            cursor: isDiscarded ? 'not-allowed' : 'pointer',
+            opacity: isDiscarded ? 0.7 : 1,
+          }}
+        >
+          Add
+        </Button>
+      </Box>
 
       <Card sx={{ p: 2 }}>
         <Box sx={{ textAlign: 'center', py: 2 }}>
@@ -41,6 +45,7 @@ const ActionLogs = ({ isDiscarded }) => (
         </Box>
       </Card>
     </Box>
-);
+  );
+};
 
 export default ActionLogs;

--- a/frontend/admin/src/components/Shipments/Detail/AddToRackCard.tsx
+++ b/frontend/admin/src/components/Shipments/Detail/AddToRackCard.tsx
@@ -1,14 +1,11 @@
 import React, { useState } from "react";
 import { Box, Typography } from "@mui/material";
+import { useShipmentDetail } from "../../../contexts/ShipmentDetailContext";
 import UpdateRackSlotModal from "./UpdateRackSlotModal";
 
-interface AddToRackCardProps {
-  shipmentId: string;
-  onRefresh: () => void;
-  isDiscarded: boolean;
-}
+const AddToRackCard: React.FC = () => {
+  const { isDiscarded } = useShipmentDetail();
 
-const AddToRackCard: React.FC<AddToRackCardProps> = ({ shipmentId, onRefresh, isDiscarded }) => {
   const [rackModalOpen, setRackModalOpen] = useState(false);
 
   const handleOpenRackModal = () => {
@@ -54,11 +51,6 @@ const AddToRackCard: React.FC<AddToRackCardProps> = ({ shipmentId, onRefresh, is
         <UpdateRackSlotModal
           open={rackModalOpen}
           onClose={handleCloseRackModal}
-          onRefresh={onRefresh}
-          shipments={{
-            id: shipmentId,
-            updated_at: "",
-          }}
         />
       )}
     </>

--- a/frontend/admin/src/components/Shipments/Detail/MeasurementRow.tsx
+++ b/frontend/admin/src/components/Shipments/Detail/MeasurementRow.tsx
@@ -1,4 +1,5 @@
 import { TableCell, TableRow } from "@mui/material";
+import { useShipmentDetail } from "../../../contexts/ShipmentDetailContext";
 import { PrintLabelButton } from "./PrintLabelButton";
 
 interface MeasurementRowProps {
@@ -7,19 +8,12 @@ interface MeasurementRowProps {
     weight: string;
     volumetricWeightDisplay: React.ReactNode;
   };
-  trackingNo?: string;
-  shipments: any;
-  isDiscarded: boolean;
 }
 
-export const MeasurementRow: React.FC<MeasurementRowProps> = ({ 
-  measurement, 
-  trackingNo, 
-  shipments, 
-  isDiscarded 
-}) => {
-  const getLabel = (trackingNo?: string) => {
-    if (!trackingNo) return '-';
+export const MeasurementRow: React.FC<MeasurementRowProps> = ({ measurement }) => {
+  const { shipment } = useShipmentDetail();
+
+  const getLabel = (trackingNo: string) => {
     const lastFour = trackingNo.slice(-4);
     return `${lastFour}-1A`;
   };
@@ -29,13 +23,10 @@ export const MeasurementRow: React.FC<MeasurementRowProps> = ({
       <TableCell sx={{ fontWeight: 600, color: '#1e293b' }}>{measurement.pieceNumber}</TableCell>
       <TableCell sx={{ fontWeight: 600, color: '#1e293b' }}>{measurement.weight}</TableCell>
       <TableCell>{measurement.volumetricWeightDisplay}</TableCell>
-      <TableCell sx={{ fontWeight: 600, color: '#1e293b' }}>{getLabel(trackingNo)}</TableCell>
+      <TableCell sx={{ fontWeight: 600, color: '#1e293b' }}>{getLabel(shipment.tracking_no)}</TableCell>
 
       <TableCell align='right' sx={{ pr: 2 }}>
-        <PrintLabelButton 
-          shipments={shipments} 
-          isDiscarded={isDiscarded} 
-        />
+        <PrintLabelButton />
       </TableCell>
     </TableRow>
   );

--- a/frontend/admin/src/components/Shipments/Detail/MeasurementsTable.tsx
+++ b/frontend/admin/src/components/Shipments/Detail/MeasurementsTable.tsx
@@ -10,21 +10,19 @@ import {
   TableRow,
 } from '@mui/material';
 
+import { useShipmentDetail } from '../../../contexts/ShipmentDetailContext';
 import { MeasurementRow } from './MeasurementRow';
 import { VolumetricWeightDisplay } from './VolumetricWeightDisplay';
 import { formatDateTime } from '../../../utils/formatDateTime';
 import { SHIPMENT_MEASUREMENTS_TABLE_HEADERS } from '../../../utils/constants';
 import { normalizeMeasurements } from '../../../utils/measurementNormalizer';
 
-interface MeasurementsTableProps {
-  shipments?: any;
-  isDiscarded: boolean;
-}
+const MeasurementsTable: React.FC = () => {
+  const { shipment } = useShipmentDetail();
 
-const MeasurementsTable: React.FC<MeasurementsTableProps> = ({ shipments, isDiscarded }) => {
   const measurements = useMemo(
-    () => normalizeMeasurements(shipments),
-    [shipments]
+    () => normalizeMeasurements(shipment),
+    [shipment]
   );
 
   function mapMeasurementToRow(m: any) {
@@ -68,9 +66,6 @@ const MeasurementsTable: React.FC<MeasurementsTableProps> = ({ shipments, isDisc
                 <MeasurementRow
                   key={index}
                   measurement={mapMeasurementToRow(m)}
-                  shipments={shipments}
-                  trackingNo={shipments?.tracking_no}
-                  isDiscarded={isDiscarded}
                 />
               ))}
             </TableBody>
@@ -91,7 +86,7 @@ const MeasurementsTable: React.FC<MeasurementsTableProps> = ({ shipments, isDisc
       )}
       
       <Typography variant="caption" sx={{ mt: 2, display: 'block', color: '#64748b', maxWidth: "250px" }}>
-        Created By {shipments?.user?.name} on {formatDateTime(shipments?.created_at)}
+        Created By {shipment?.user?.name} on {formatDateTime(shipment?.created_at)}
       </Typography>
     </Box>
   );

--- a/frontend/admin/src/components/Shipments/Detail/PackagesSection.tsx
+++ b/frontend/admin/src/components/Shipments/Detail/PackagesSection.tsx
@@ -1,93 +1,85 @@
-import { Box, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@mui/material";
-import PackageRow from "../PackageRow";
 import type React from "react";
+import { Box, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@mui/material";
 
-interface PackagesSectionProps {
-  packages: any[];
-  shipmentId: string;
-  onPackageRemoved: () => void;
-  isDiscarded: boolean;
-}
+import { useShipmentDetail } from "../../../contexts/ShipmentDetailContext";
+import PackageRow from "../PackageRow";
 
-const PackagesSection: React.FC<PackagesSectionProps> = ({
-  packages,
-  shipmentId,
-  onPackageRemoved,
-  isDiscarded,
-}) => {
-    return (
-        <Box sx={{ width: '100%', mt: 3 }}>
-            <Typography
-              variant="h6"
-              sx={{
+const PackagesSection: React.FC = () => {
+  const { shipment, isDiscarded, fetchShipments } = useShipmentDetail();
+
+  return (
+    <Box sx={{ width: '100%', mt: 3 }}>
+      <Typography
+        variant="h6"
+        sx={{
+          fontWeight: 600,
+          color: '#374151',
+          mb: 1.5,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+        }}
+      >
+        Packages ({shipment.packages.length})
+      </Typography>
+        
+      <Box sx={{ 
+        bgcolor: 'white', 
+        borderRadius: 2, 
+        border: '1px solid #e2e8f0',
+        overflow: 'hidden',
+        width: '100%'
+      }}>
+        <Table
+          size="small"
+          sx={{
+            tableLayout: "auto",
+            width: "100%",
+            borderCollapse: "separate",
+            borderSpacing: 0,
+            '& td, & th': {
+              paddingY: 1,
+              paddingX: 1.5,
+            }
+          }}>
+          <TableHead>
+            <TableRow sx={{ 
+              bgcolor: '#f1f5f9',
+              '& > *': { 
+                border: 'none',
                 fontWeight: 600,
-                color: '#374151',
-                mb: 1.5,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 1,
-              }}
-            >
-              Packages ({packages.length})
-            </Typography>
-            
-            <Box sx={{ 
-              bgcolor: 'white', 
-              borderRadius: 2, 
-              border: '1px solid #e2e8f0',
-              overflow: 'hidden',
-              width: '100%'
+                color: "#6b7280",
+                fontSize: '0.875rem',
+                py: 1.5
+              } 
             }}>
-              <Table
-                size="small"
-                sx={{
-                  tableLayout: "auto",
-                  width: "100%",
-                  borderCollapse: "separate",
-                  borderSpacing: 0,
-                  '& td, & th': {
-                    paddingY: 1,
-                    paddingX: 1.5,
-                  }
-                }}>
-                <TableHead>
-                  <TableRow sx={{ 
-                    bgcolor: '#f1f5f9',
-                    '& > *': { 
-                      border: 'none',
-                      fontWeight: 600,
-                      color: "#6b7280",
-                      fontSize: '0.875rem',
-                      py: 1.5
-                    } 
-                  }}>
-                    <TableCell sx={{ fontWeight: 600, color: "#6b7280",width: 200, textAlign: "center" }}>Package No.</TableCell>
-                    <TableCell>Rack</TableCell>
-                    <TableCell>Tracking No.</TableCell>
-                    <TableCell>Received At</TableCell>
-                    <TableCell>Weight</TableCell>
-                    <TableCell sx={{ fontWeight: 600, color: "#6b7280", width: 100 }}>Vol. Weight</TableCell>
-                    <TableCell sx={{ width: 80 }} />
-                  </TableRow>
-                </TableHead>
+              <TableCell sx={{ fontWeight: 600, color: "#6b7280",width: 200, textAlign: "center" }}>Package No.</TableCell>
+              <TableCell>Rack</TableCell>
+              <TableCell>Tracking No.</TableCell>
+              <TableCell>Received At</TableCell>
+              <TableCell>Weight</TableCell>
+              <TableCell sx={{ fontWeight: 600, color: "#6b7280", width: 100 }}>Vol. Weight</TableCell>
+              <TableCell sx={{ width: 80 }} />
+            </TableRow>
+          </TableHead>
 
-                <TableBody>
-                  {packages.map((pkg, i) => (
-                    <PackageRow 
-                      key={pkg.id} 
-                      item={pkg} 
-                      index={i}
-                      showCancel
-                      shipmentId={shipmentId}
-                      onPackageRemoved={onPackageRemoved}
-                      isDiscarded={isDiscarded}
-                    />
-                  ))}
-                </TableBody>
-              </Table>
-            </Box>
-        </Box>
-    )
+          <TableBody>
+            {shipment.packages.map((pkg, i) => (
+              <PackageRow 
+                key={pkg.id} 
+                item={pkg} 
+                index={i}
+                showCancel
+                shipmentId={shipment.id}
+                onPackageRemoved={fetchShipments}
+                isDiscarded={isDiscarded}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
+    </Box>
+  )
 }
 
 export default PackagesSection;

--- a/frontend/admin/src/components/Shipments/Detail/PrintLabelButton.tsx
+++ b/frontend/admin/src/components/Shipments/Detail/PrintLabelButton.tsx
@@ -2,21 +2,20 @@ import { useState } from "react";
 import { CircularProgress, IconButton } from "@mui/material";
 import PrintIcon from '@mui/icons-material/Print';
 import { toast } from "sonner";
+
+import { useShipmentDetail } from "../../../contexts/ShipmentDetailContext";
 import { generateCarrierLabelPDF } from "../../PDF/CarrierLabelPDF";
 
-interface PrintLabelButtonProps {
-  shipments: any;
-  isDiscarded: boolean;
-}
+export const PrintLabelButton: React.FC = () => {
+  const { shipment, isDiscarded } = useShipmentDetail();
 
-export const PrintLabelButton: React.FC<PrintLabelButtonProps> = ({ shipments, isDiscarded }) => {
   const [loading, setLoading] = useState(false);
 
   const handlePrintClick = async () => {
-    if (!shipments) return;
+    if (!shipment) return;
     setLoading(true);
     try {
-      await generateCarrierLabelPDF({ ...shipments, num_pieces: "1 PCS" });
+      await generateCarrierLabelPDF({ ...shipment, num_pieces: "1 PCS" });
       toast.success("Carrier label generated");
     } catch (error) {
       toast.error("Failed to generate Carrier Label PDF");

--- a/frontend/admin/src/components/Shipments/Detail/RackSlotInfo.tsx
+++ b/frontend/admin/src/components/Shipments/Detail/RackSlotInfo.tsx
@@ -1,27 +1,12 @@
 import React, { useState } from 'react';
 import { Box, Typography } from '@mui/material';
+
+import { useShipmentDetail } from '../../../contexts/ShipmentDetailContext';
 import UpdateRackSlotModal from './UpdateRackSlotModal';
 
-interface RackSlotInfoProps {
-  shipments: {
-    id: string;
-    tracking_no: string;
-    rack_slot?: {
-      label: string;
-      color: string;
-      count?: number;
-    };
-    updated_by?: {
-      name: string;
-    }
-    updated_at: string;
-    [key: string]: unknown; 
-  };
-  onRefresh: () => void;
-  isDiscarded: boolean;
-}
+const RackSlotInfo: React.FC = () => {
+  const { shipment, isDiscarded } = useShipmentDetail();
 
-const RackSlotInfo: React.FC<RackSlotInfoProps> = ({ shipments, onRefresh, isDiscarded }) => {
   const [rackModalOpen, setRackModalOpen] = useState(false);
 
   const handleOpenRackModal = () => {
@@ -48,10 +33,10 @@ const RackSlotInfo: React.FC<RackSlotInfoProps> = ({ shipments, onRefresh, isDis
         }}
       >
         <Typography variant="body2" sx={{ fontWeight: 600, color: '#166534', display: 'flex', alignItems: 'center', gap: 1 }}>
-          {shipments.rack_slot?.label} →
+          {shipment.rack_slot?.label} →
         </Typography>
         <Typography variant="body2" sx={{ fontWeight: 500, color: '#166534' }}>
-          {`Slot has ${shipments.rack_slot?.count} pkgs`}
+          {`Slot has ${shipment.rack_slot?.count} pkgs`}
         </Typography>
       </Box>
 
@@ -59,13 +44,6 @@ const RackSlotInfo: React.FC<RackSlotInfoProps> = ({ shipments, onRefresh, isDis
         <UpdateRackSlotModal
           open={rackModalOpen}
           onClose={handleCloseRackModal}
-          onRefresh={onRefresh}
-          shipments={{
-            id: shipments.id,
-            rack_slot: shipments.rack_slot,
-            updated_by: shipments.updated_by,
-            updated_at: shipments.updated_at,
-          }}
         />
       )}
     </>

--- a/frontend/admin/src/components/Shipments/Detail/ShipmentDetailsSection.tsx
+++ b/frontend/admin/src/components/Shipments/Detail/ShipmentDetailsSection.tsx
@@ -1,20 +1,12 @@
 import React, { useMemo, useState } from 'react';
 import { Edit as EditIcon } from '@mui/icons-material';
 import { Box, Typography, Card, CardContent, Button, CircularProgress } from '@mui/material';
+
+import { useShipmentDetail } from '../../../contexts/ShipmentDetailContext';
 import RackSlotInfo from './RackSlotInfo';
 import AddToRackCard from './AddToRackCard';
 import MeasurementsTable from './MeasurementsTable';
 import UpdateInfoModal from './UpdateInfoModal';
-
-interface Items {
-  total_price: number;
-}
-
-interface Package {
-  total_weight: string;
-  total_volumetric_weight: string;
-  items: Items[];
-}
 
 export interface Pieces {
   id: string;
@@ -24,54 +16,18 @@ export interface Pieces {
   width: number;
   height: number;
   volumetric_weight: number;
-  created_at: number;
-  updated_at: number;
 }
 
-interface ShipmentDetailsSectionProps {
-  shipments: {
-    id: string;
-    tracking_no: string;
-    packages: Package[];
-    pieces: Pieces[];
-    dangerous_good: string;
-    customs_value: string;
-    total_weight: number;
-    total_volumetric_weight: number;
-    length: number;
-    width: number;
-    height: number;
-    manifested?: boolean;
-    created_by?: {
-      name: string;
-    }
-    created_at: string;
-    updated_at: string;
-    status?: string;
-    rack_slot?: {
-      label: string;
-      color: string;
-      count?: number
-    }
-  };
-  loading?: boolean
-  onRefresh: () => void;
-  isDiscarded: boolean;
-}
+const ShipmentDetailsSection: React.FC = () => {
+  const { shipment, loading, isDiscarded } = useShipmentDetail();
 
-const ShipmentDetailsSection: React.FC<ShipmentDetailsSectionProps> = ({
-  shipments,
-  loading,
-  onRefresh,
-  isDiscarded,
-}) => {
   const [infoModalOpen, setInfoModalOpen] = useState(false);
 
   const handleOpenInfoModal = () => setInfoModalOpen(true);
   const handleCloseInfoModal = () => setInfoModalOpen(false);
 
   const { totalWeight, totalVolumetricWeight } = useMemo(() => {
-    const pieces = shipments?.pieces || [];
+    const pieces = shipment?.pieces || [];
 
     if (pieces.length > 0) {
       const totalWeight = pieces.reduce((acc: number, p: any) => acc + parseFloat(p.weight || '0'), 0);
@@ -79,7 +35,7 @@ const ShipmentDetailsSection: React.FC<ShipmentDetailsSectionProps> = ({
       return { totalWeight, totalVolumetricWeight };
     }
 
-    const packages = shipments?.packages || [];
+    const packages = shipment?.packages || [];
     
     if (!packages.length) {
       return { totalWeight: 0, totalVolumetricWeight: 0 };
@@ -96,31 +52,31 @@ const ShipmentDetailsSection: React.FC<ShipmentDetailsSectionProps> = ({
     }, 0);
 
     return { totalWeight, totalVolumetricWeight };
-  }, [shipments.packages, shipments.pieces]);
+  }, [shipment.packages, shipment.pieces]);
 
-  const packagesCount = (shipments?.packages || []).length;
+  const packagesCount = (shipment?.packages || []).length;
 
   return (
     <>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-            <Typography variant="h6" sx={{ fontWeight: 600, color: '#1e293b' }}>
-              Shipment Details
-            </Typography>
-            <Button
-              variant="contained"
-              startIcon={<EditIcon />}
-              onClick={handleOpenInfoModal}
-              disabled={isDiscarded}
-              sx={{
-                bgcolor: '#3b82f6',
-                '&:hover': { bgcolor: '#2563eb' },
-                textTransform: 'none',
-                borderRadius: 1
-              }}
-            >
-              Update Information
-            </Button>
-        </Box>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, color: '#1e293b' }}>
+          Shipment Details
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<EditIcon />}
+          onClick={handleOpenInfoModal}
+          disabled={isDiscarded}
+          sx={{
+            bgcolor: '#3b82f6',
+            '&:hover': { bgcolor: '#2563eb' },
+            textTransform: 'none',
+            borderRadius: 1
+          }}
+        >
+          Update Information
+        </Button>
+      </Box>
 
       <Card sx={{ mb: 3, position: 'relative' }}>
         {loading && (
@@ -155,7 +111,7 @@ const ShipmentDetailsSection: React.FC<ShipmentDetailsSectionProps> = ({
                 UGFLASH (air)
               </Typography>
               <Typography variant="body1" sx={{ fontWeight: 600, color: '#1e293b' }}>
-                {shipments.tracking_no}
+                {shipment.tracking_no}
               </Typography>
             </Box>
 
@@ -188,7 +144,7 @@ const ShipmentDetailsSection: React.FC<ShipmentDetailsSectionProps> = ({
                 Customs Value
               </Typography>
               <Typography variant="body1" sx={{ fontWeight: 600, color: '#1e293b' }}>
-                {shipments.customs_value ? `$${parseFloat(shipments.customs_value).toFixed(2)}` : '0.00'}
+                {shipment.customs_value ? `$${parseFloat(shipment.customs_value).toFixed(2)}` : '0.00'}
               </Typography>
             </Box>
 
@@ -197,7 +153,7 @@ const ShipmentDetailsSection: React.FC<ShipmentDetailsSectionProps> = ({
                 Dangerous Good
               </Typography>
               <Typography variant="body1" sx={{ fontWeight: 600, color: '#1e293b' }}>
-                {shipments?.dangerous_good ? '⛔️ Yes' : 'No'}
+                {shipment?.dangerous_good ? '⛔️ Yes' : 'No'}
               </Typography>
             </Box>
 
@@ -223,7 +179,7 @@ const ShipmentDetailsSection: React.FC<ShipmentDetailsSectionProps> = ({
                 Manifested
               </Typography>
               <Typography variant="body1" sx={{ fontWeight: 600, color: '#1e293b' }}>
-                {shipments.manifested ? 'Yes' : 'No'}
+                {shipment.manifested ? 'Yes' : 'No'}
               </Typography>
             </Box>
             <Box sx={{ 
@@ -236,28 +192,17 @@ const ShipmentDetailsSection: React.FC<ShipmentDetailsSectionProps> = ({
                 display: 'flex',
                 alignItems: 'flex-start'
               }}>
-                {shipments.rack_slot ? (
-                  <RackSlotInfo
-                    shipments={shipments}
-                    onRefresh={onRefresh}
-                    isDiscarded={isDiscarded}
-                  />
+                {shipment.rack_slot ? (
+                  <RackSlotInfo />
                 ) : (
-                  <AddToRackCard
-                    shipmentId={shipments.id}
-                    onRefresh={onRefresh}
-                    isDiscarded={isDiscarded}
-                  />
+                  <AddToRackCard />
                 )}
               </Box>
             </Box>
           </Box>
 
           <Box sx={{ mt: 3 }}>
-            <MeasurementsTable 
-              shipments={shipments}
-              isDiscarded={isDiscarded}
-            />
+            <MeasurementsTable />
           </Box>
         </CardContent>
       </Card>
@@ -266,8 +211,6 @@ const ShipmentDetailsSection: React.FC<ShipmentDetailsSectionProps> = ({
         <UpdateInfoModal
           open={infoModalOpen}
           onClose={handleCloseInfoModal}
-          onRefresh={onRefresh}
-          shipments={shipments}
         />
       )}
     </>

--- a/frontend/admin/src/components/Shipments/Detail/ShipmentHeader.tsx
+++ b/frontend/admin/src/components/Shipments/Detail/ShipmentHeader.tsx
@@ -1,43 +1,37 @@
 import React from 'react';
+
+import { useShipmentDetail } from '../../../contexts/ShipmentDetailContext';
+import RequestHeader from '../../common/RequestHeader';
 import StatusActionButtons from '../../StatusActionButtons/StatusActionButtons';
 import { FEATURE_CONFIG } from '../../../utils/trackingConfig';
-import RequestHeader from '../../common/RequestHeader';
 import { getStatusColor } from '../../../utils/statusUtils';
 
-interface ShipmentHeaderProps {
-  shipments: any;
-  onRefresh?: () => void;
-  isDiscarded: boolean;
-}
+const ShipmentHeader: React.FC = () => {
+  const { shipment, isDiscarded, fetchShipments } = useShipmentDetail();
 
-const ShipmentHeader: React.FC<ShipmentHeaderProps> = ({ 
-  shipments,
-  onRefresh,
-  isDiscarded
-}) => {
   const user = {
-    name: shipments.user?.name || '',
-    suite_no: shipments.user?.suite_no ?? '',
-    email: shipments.user?.email ?? '',
-    phone: shipments.user?.phone_number === 'N/A' ? null : shipments.user?.phone_number,
-    alt_phone: shipments.user?.phone_number_2 === 'N/A' ? null : shipments?.phone_number_2,
+    name: shipment.user?.name || '',
+    suite_no: shipment.user?.suite_no ?? '',
+    email: shipment.user?.email ?? '',
+    phone: shipment.user?.phone_number === 'N/A' ? null : shipment.user?.phone_number,
+    alt_phone: shipment.user?.phone_number_2 === 'N/A' ? null : shipment?.phone_number_2,
   };
 
   const actionButtons = (
     <StatusActionButtons
       feature={FEATURE_CONFIG.SHIPMENT}
-      status={shipments.status ?? ''}
-      data={shipments}
-      onRefresh={onRefresh}
+      status={shipment.status ?? ''}
+      data={shipment}
+      onRefresh={fetchShipments}
       disabled={isDiscarded}
     />
   );
   return (
     <RequestHeader
       title="Shipment"
-      requestCode={shipments.shipment_no!}
-      statusDisplay={shipments.status ?? ''}
-      statusChipStyles={getStatusColor(shipments.status ?? '')}
+      requestCode={shipment.shipment_no}
+      statusDisplay={shipment.status ?? ''}
+      statusChipStyles={getStatusColor(shipment.status ?? '')}
       user={user}
       actionButtons={actionButtons}
     />

--- a/frontend/admin/src/components/Shipments/Detail/ShipmentsPhotosSection.tsx
+++ b/frontend/admin/src/components/Shipments/Detail/ShipmentsPhotosSection.tsx
@@ -2,45 +2,22 @@ import React, { useRef, useState } from "react";
 import { toast } from "sonner";
 import { Box, Button, Card, CardContent, CircularProgress, Typography } from "@mui/material";
 import { Add as AddIcon, CloudUpload as UploadIcon, PictureAsPdf as PictureAsPdfIcon } from '@mui/icons-material';
+
+import { useShipmentDetail } from "../../../contexts/ShipmentDetailContext";
+import { createShipmentDocument } from "../../../services/api.services";
 import { uploadToCloudinary } from "../../../utils/cloudinary.api";
 import { formatFileName } from "../../../utils/formatFileName";
-import { createShipmentDocument } from "../../../services/api.services";
 import { formatDateTime } from "../../../utils/formatDateTime";
 
-interface Document {
-  id: string;
-  document_url: string;
-  original_filename: string;
-  mime_type: string;
-}
+const ShipmentsPhotosSection: React.FC = () => {
+    const { shipment, isDiscarded, fetchShipments } = useShipmentDetail();
+    const documents = shipment.shipment_photos || [];
 
-interface Shipments {
-  id?: string;
-  created_by?: {
-    name: string;
-  }
-  created_at?: string;
-  [key: string]: unknown;
-}
-
-interface ShipmentsPhotosSectionProps {
-  shipments: Shipments;
-  documents: Document[];
-  onUploadSuccess?: () => Promise<void>;
-  isDiscarded: boolean;
-}
-
-const ShipmentsPhotosSection: React.FC<ShipmentsPhotosSectionProps> = ({
-    shipments,
-    documents,
-    onUploadSuccess,
-    isDiscarded,
-}) => {
     const [uploading, setUploading] = useState(false);
     const [isDragOver, setIsDragOver] = useState(false);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-    const isUploadDisabled = !shipments.id;
+    const isUploadDisabled = !shipment.id;
     
     const handleFileSelect = async (files: FileList | null) => {
       if (isUploadDisabled) {
@@ -56,7 +33,7 @@ const ShipmentsPhotosSection: React.FC<ShipmentsPhotosSectionProps> = ({
         for (const file of filesArray) {
           const url = await uploadToCloudinary(file);
           if (url) {
-            await createShipmentDocument(shipments.id!, {
+            await createShipmentDocument(shipment.id!, {
               url,
               original_filename: file.name,
               mime_type: file.type,
@@ -65,7 +42,7 @@ const ShipmentsPhotosSection: React.FC<ShipmentsPhotosSectionProps> = ({
             })
           }
         }
-        await onUploadSuccess?.();
+        await fetchShipments();
         toast.success('Files uploaded successfully');
       } catch (error) {
         console.error('Upload failed:', error);
@@ -265,7 +242,7 @@ const ShipmentsPhotosSection: React.FC<ShipmentsPhotosSectionProps> = ({
                     )}
 
                     <Typography variant="caption" sx={{ color: '#64748b', fontSize: '0.75rem' }}>
-                      {shipments.created_by?.name} {formatDateTime(shipments.created_at)}
+                      {shipment.created_by?.name} {formatDateTime(shipment.created_at)}
                     </Typography>
                   </Box>
                 </Box>

--- a/frontend/admin/src/components/Shipments/Detail/ShippingAddress.tsx
+++ b/frontend/admin/src/components/Shipments/Detail/ShippingAddress.tsx
@@ -1,13 +1,12 @@
 import React from "react";
 import { Box, Card, CardContent, Typography } from "@mui/material";
 import PublicIcon from "@mui/icons-material/Public";
+import { useShipmentDetail } from "../../../contexts/ShipmentDetailContext";
 
-interface ShippingAddressProps {
-  shipments: any;
-}
+const ShippingAddress: React.FC = () => {
+  const { shipment } = useShipmentDetail();
 
-const ShippingAddress: React.FC<ShippingAddressProps> = ({ shipments }) => {
-  const user = shipments?.user;
+  const user = shipment?.user;
   const courier = user?.preference?.courier;
   const address = courier?.address || '';
 

--- a/frontend/admin/src/components/Shipments/Detail/UpdateInfoModal.tsx
+++ b/frontend/admin/src/components/Shipments/Detail/UpdateInfoModal.tsx
@@ -13,8 +13,10 @@ import {
   Typography,
   CircularProgress,
 } from "@mui/material";
-import WeightSection from "./WeightSection";
+
+import { useShipmentDetail } from "../../../contexts/ShipmentDetailContext";
 import { updateShipment } from "../../../services/api.services";
+import WeightSection from "./WeightSection";
 import type { Pieces } from "./ShipmentDetailsSection";
 
 interface PieceData {
@@ -44,8 +46,6 @@ interface Shipment {
 interface UpdateInfoModalProps {
   open: boolean;
   onClose: () => void;
-  onRefresh: () => void;
-  shipments: Shipment;
 }
 
 const getInitialFormData = (shipmentData: Shipment): FormData => {
@@ -87,27 +87,24 @@ const getInitialFormData = (shipmentData: Shipment): FormData => {
   };
 };
 
-const UpdateInfoModal: React.FC<UpdateInfoModalProps> = ({
-  open,
-  onClose,
-  onRefresh,
-  shipments,
-}) => {
+const UpdateInfoModal: React.FC<UpdateInfoModalProps> = ({ open, onClose }) => {
+  const { shipment, fetchShipments } = useShipmentDetail();
+
   const [saving, setSaving] = useState(false);
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [initialFormData, setInitialFormData] = useState<FormData>(() =>
-    getInitialFormData(shipments)
+    getInitialFormData(shipment)
   );
   const [formData, setFormData] = useState<FormData>(initialFormData);
 
   useEffect(() => {
     if (open) {
-      const newInitialData = getInitialFormData(shipments);
+      const newInitialData = getInitialFormData(shipment);
       setInitialFormData(newInitialData);
       setFormData(newInitialData);
       setErrors({});
     }
-  }, [shipments, open]);
+  }, [shipment, open]);
 
   const handleCustomsValueChange = (
     e: React.ChangeEvent<HTMLInputElement>
@@ -291,8 +288,8 @@ const UpdateInfoModal: React.FC<UpdateInfoModalProps> = ({
         pieces: piecesPayload,
       };
 
-      await updateShipment(shipments.id, payload);
-      onRefresh();
+      await updateShipment(shipment.id, payload);
+      fetchShipments();
       onClose();
     } catch (err) {
       console.error("Failed to update package", err);

--- a/frontend/admin/src/components/Shipments/Detail/UpdateRackSlotModal.tsx
+++ b/frontend/admin/src/components/Shipments/Detail/UpdateRackSlotModal.tsx
@@ -3,26 +3,19 @@ import {
   Dialog, DialogTitle, DialogContent, Box, Grid, TextField, Button, CircularProgress, MenuItem, Stack, Typography, IconButton
 } from '@mui/material';
 import { CloseOutlined } from '@mui/icons-material';
-import type { Rack } from '../../../types';
+
+import { useShipmentDetail } from '../../../contexts/ShipmentDetailContext';
 import { getRacks, updateShipment } from '../../../services/api.services';
+import type { Rack } from '../../../types';
 
 interface UpdateRackSlotModalProps {
   open: boolean;
   onClose: () => void;
-  onRefresh: () => void;
-  shipments: {
-    id: string;
-    rack_slot?:{
-      label: string;
-    };
-    updated_by?: {
-      name: string;
-    };
-    updated_at: string;
-  };
 }
 
-const UpdateRackSlotModal: React.FC<UpdateRackSlotModalProps> = ({ open, onClose, onRefresh, shipments }) => {
+const UpdateRackSlotModal: React.FC<UpdateRackSlotModalProps> = ({ open, onClose }) => {
+  const { shipment, fetchShipments } = useShipmentDetail();
+
   const [rackSlots, setRackSlots] = useState<Rack[]>([]);
   const [selectedRackSlot, setSelectedRackSlot] = useState('');
   const [saving, setSaving] = useState(false);
@@ -33,7 +26,7 @@ const UpdateRackSlotModal: React.FC<UpdateRackSlotModalProps> = ({ open, onClose
     try {
       const data = await getRacks();
       setRackSlots(data);
-      const currentRack = data.find((r) => r.label === shipments.rack_slot?.label);
+      const currentRack = data.find((r) => r.label === shipment.rack_slot?.label);
       if (currentRack) {
         setSelectedRackSlot(currentRack.id);
       }
@@ -42,7 +35,7 @@ const UpdateRackSlotModal: React.FC<UpdateRackSlotModalProps> = ({ open, onClose
     } finally {
       setLoadingRacks(false);
     }
-  }, [shipments.rack_slot?.label]);
+  }, [shipment.rack_slot?.label]);
 
   useEffect(() => {
     if (open) {
@@ -51,16 +44,16 @@ const UpdateRackSlotModal: React.FC<UpdateRackSlotModalProps> = ({ open, onClose
   }, [open, fetchRacks]);
 
   const currentRack = useMemo(() =>
-    rackSlots.find(r => r.id === selectedRackSlot || r.label === shipments.rack_slot?.label),
-    [rackSlots, selectedRackSlot, shipments.rack_slot?.label]
+    rackSlots.find(r => r.id === selectedRackSlot || r.label === shipment.rack_slot?.label),
+    [rackSlots, selectedRackSlot, shipment.rack_slot?.label]
   );
 
   const handleSaveRackSlot = async () => {
     if (!selectedRackSlot) return;
     setSaving(true);
     try {
-      await updateShipment(shipments.id, { rack_slot: selectedRackSlot });
-      onRefresh();
+      await updateShipment(shipment.id, { rack_slot: selectedRackSlot });
+      fetchShipments();
       onClose();
     } catch (err) {
       console.error("Failed to update rack slot", err);
@@ -140,7 +133,7 @@ const UpdateRackSlotModal: React.FC<UpdateRackSlotModalProps> = ({ open, onClose
                   onClick={handleSaveRackSlot}
                   variant="contained"
                   fullWidth
-                  disabled={saving || !selectedRackSlot || selectedRackSlot === rackSlots.find(r => r.label === shipments.rack_slot?.label)?.id}
+                  disabled={saving || !selectedRackSlot || selectedRackSlot === rackSlots.find(r => r.label === shipment.rack_slot?.label)?.id}
                   sx={{
                     textTransform: 'none',
                     bgcolor: '#4f46e5',
@@ -152,7 +145,7 @@ const UpdateRackSlotModal: React.FC<UpdateRackSlotModalProps> = ({ open, onClose
               </Grid>
             </Grid>
 
-            {shipments.rack_slot && currentRack && (
+            {shipment.rack_slot && currentRack && (
               <Box sx={{ mt: 3, borderTop: '1px solid #e2e8f0', pt: 3 }}>
                 <Stack direction="row" alignItems="center" spacing={2}>
                   <Box
@@ -170,7 +163,7 @@ const UpdateRackSlotModal: React.FC<UpdateRackSlotModalProps> = ({ open, onClose
                       {currentRack.label}
                     </Typography>
                     <Typography variant="caption" sx={{ color: '#64748b' }}>
-                      {shipments.updated_by?.name} on {shipments.updated_at}
+                      {shipment.updated_by?.name} on {shipment.updated_at}
                     </Typography>
                   </Box>
                 </Stack>

--- a/frontend/admin/src/contexts/ShipmentDetailContext.tsx
+++ b/frontend/admin/src/contexts/ShipmentDetailContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
+import { useParams } from "react-router-dom";
+import { getShipmentsByShipmentNo } from "../services/api.services";
+
+interface ShipmentDetailContextType {
+  shipment: any | null;
+  loading: boolean;
+  isDiscarded: boolean;
+  fetchShipments: () => Promise<void>;
+}
+
+const ShipmentDetailContext = createContext< ShipmentDetailContextType | undefined >(undefined);
+
+export const ShipmentDetailProvider = ({ children }: { children: ReactNode }) => {
+  const { shipment_no } = useParams();
+
+  const [shipment, setShipment] = useState<any | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchShipments = useCallback(async () => {
+    if (!shipment_no) return;
+    setLoading(true);
+    try {
+      const data = await getShipmentsByShipmentNo(shipment_no);
+      setShipment(data);
+    } catch (err) {
+      console.error("Error fetching shopping request:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [shipment_no]);
+  
+  useEffect(() => {
+    fetchShipments();
+  }, [fetchShipments]);
+
+  const isDiscarded = shipment?.status === 'DISCARDED';
+
+  return (
+    <ShipmentDetailContext.Provider
+      value={{
+        shipment,
+        loading,
+        isDiscarded,
+        fetchShipments,
+      }}
+    >
+      {children}
+    </ShipmentDetailContext.Provider>
+  );
+};
+
+export const useShipmentDetail = () => {
+  const context = useContext(ShipmentDetailContext);
+  if (!context) {
+    throw new Error('useShipmentDetail must be used within ShipmentDetailProvider')
+  }
+  return context;
+};

--- a/frontend/admin/src/pages/PickupRequestDetail.tsx
+++ b/frontend/admin/src/pages/PickupRequestDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Box, CircularProgress} from '@mui/material';
+import { Box, CircularProgress, Typography } from '@mui/material';
 import { useParams } from 'react-router-dom';
 
 import { getPickupRequestById } from '../services/api.services.ts';
@@ -41,11 +41,24 @@ const PickupRequestDetail: React.FC = () => {
     );
   }
 
+   if (!pickupRequest) {
+    return (
+      <Box>
+        <TopNavbar pageTitle="Pickup Request" pageSubtitle="All" />
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 400 }}>
+          <Typography variant="h6" color="text.secondary">
+            Pickup request not found
+          </Typography>
+        </Box>
+      </Box>
+    );
+  }
+
   return (
     <Box>
       <TopNavbar pageTitle="Pickup Request" pageSubtitle="All" />
-      {pickupRequest && <RequestDetailHeader request={pickupRequest} onStatusUpdate={fetchRequest} />}
-      {pickupRequest && <RequestDetailContent request={pickupRequest} />}
+      <RequestDetailHeader request={pickupRequest} onStatusUpdate={fetchRequest} />
+      <RequestDetailContent request={pickupRequest} />
     </Box>
   );
 };

--- a/frontend/admin/src/pages/ShipmentDetail.tsx
+++ b/frontend/admin/src/pages/ShipmentDetail.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Alert, Box, CircularProgress, Grid } from '@mui/material';
-import { useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
-import { getShipmentsByShipmentNo, updateShipmentStatus } from '../services/api.services.ts';
+import { ShipmentDetailProvider, useShipmentDetail } from '../contexts/ShipmentDetailContext.tsx';
+import { updateShipmentStatus } from '../services/api.services.ts';
 import TopNavbar from '../components/Layout/TopNavbar.tsx';
 import ShipmentDetailsSection from '../components/Shipments/Detail/ShipmentDetailsSection.tsx';
 import PackagesSection from '../components/Shipments/Detail/PackagesSection.tsx';
@@ -17,28 +17,10 @@ import { SHIPMENT_STATUS_TO_STEP_ID_MAPPING, SHIPMENT_TRACKING_STEPS } from '../
 import { formatDateTime } from '../utils/formatDateTime.ts';
 import { formatWithPlaceholders } from '../utils/formatPlaceholder.ts';
 
-const ShipmentDetail: React.FC = () => {
-  const { shipment_no } = useParams();
-  const [shipments, setShipments] = useState<any | null>(null);
+const ShipmentDetailContent: React.FC = () => {
+  const { shipment, loading, isDiscarded, fetchShipments } = useShipmentDetail();
+
   const [isApprovingPayment, setIsApprovingPayment] = useState(false);
-  const [loading, setLoading] = useState(true);
-
-  const fetchShipments = useCallback(async () => {
-    if (!shipment_no) return;
-    setLoading(true);
-    try {
-      const data = await getShipmentsByShipmentNo(shipment_no);
-      setShipments(data);
-    } catch (err) {
-      console.error("Error fetching shopping request:", err);
-    } finally {
-      setLoading(false);
-    }
-  }, [shipment_no]);
-
-  useEffect(() => {
-    fetchShipments();
-  }, [fetchShipments]);
 
   const handleApprovePayment = async (id: string) => {
     if (!id) return;
@@ -117,7 +99,7 @@ const ShipmentDetail: React.FC = () => {
     });
   };
   
-  if (loading || !shipments) {
+  if (loading) {
     return (
       <Box sx={{ p: 1 }}>
         <TopNavbar />
@@ -128,81 +110,77 @@ const ShipmentDetail: React.FC = () => {
     );
   }
 
-  const { statuses, currentStageId } = getTrackingViewData(shipments);
-  const showInvoiceTable = ["PAYMENT_PENDING", "PAYMENT_APPROVAL_PENDING", "PAYMENT_APPROVED", "READY_TO_SHIP", "DEPARTED", "DISCARDED"]
-    .includes(shipments.status);
+  if (!shipment) {
+    return (
+      <Box sx={{ p: 1 }}>
+        <TopNavbar />
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 400 }}>
+          Shipment not found.
+        </Box>
+      </Box>
+    )
+  }
 
-  const isDiscarded = shipments.status === 'DISCARDED';
-  const showDiscardedMessage = isDiscarded && (
-    <Alert severity="warning" sx={{ mt: 2, mb: 2 }}>
-      This shipment has been discarded. No further actions can be taken.
-    </Alert>
-  );
+  const { statuses, currentStageId } = getTrackingViewData(shipment);
+  const showInvoiceTable = ["PAYMENT_PENDING", "PAYMENT_APPROVAL_PENDING", "PAYMENT_APPROVED", "READY_TO_SHIP", "DEPARTED", "DISCARDED"]
+    .includes(shipment.status);
 
   return (
     <Box sx={{ p: 1 }}>
       <TopNavbar
         pageTitle="Shipments"
-        pageSubtitle={shipment_no}
+        pageSubtitle={shipment.shipment_no}
       />
-      {showDiscardedMessage}
+      
+      {isDiscarded && (
+        <Alert severity="warning" sx={{ mt: 2, mb: 2 }}>
+          This shipment has been discarded. No further actions can be taken.
+        </Alert>
+      )}
 
-      <ShipmentHeader 
-        shipments={shipments}
-        onRefresh={fetchShipments}
-        isDiscarded={isDiscarded}
-      />
+      <ShipmentHeader />
 
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 8 }}  sx={{ mt: 2 }}>
-          <ShipmentDetailsSection 
-            shipments={shipments}
-            loading={loading}
-            onRefresh={fetchShipments}
-            isDiscarded={isDiscarded}
-          />
+          <ShipmentDetailsSection />
 
-          <PackagesSection
-            packages={shipments?.packages}
-            shipmentId={shipments?.id}
-            onPackageRemoved={fetchShipments} 
-            isDiscarded={isDiscarded}
-          />
+          <PackagesSection />
 
           {showInvoiceTable && (
             <InvoiceTable
-              invoice={shipments.invoice}
-              payment_slips={shipments.payment_slips}
-              status={shipments.status}
+              invoice={shipment.invoice}
+              payment_slips={shipment.payment_slips}
+              status={shipment.status}
               isApprovingPayment={isApprovingPayment}
-              onApprovePayment={() => handleApprovePayment(shipments.id)} 
+              onApprovePayment={() => handleApprovePayment(shipment.id)} 
               isDiscarded={isDiscarded}
             />
           )}           
         </Grid>
 
         <Grid size={{ xs: 12, md: 4 }}>
-          <ShippingAddress
-            shipments={shipments}
-          />
+          <ShippingAddress />
 
-          <ShipmentsPhotosSection 
-            shipments={shipments}
-            documents={shipments.shipment_photos || []}
-            onUploadSuccess={fetchShipments}
-            isDiscarded={isDiscarded}
-          />
+          <ShipmentsPhotosSection />
 
           <TrackingStatus
             statuses={statuses}
             currentStageId={currentStageId}
           />
 
-          <ActionLogs isDiscarded={isDiscarded}/> 
+          <ActionLogs /> 
         </Grid>
       </Grid>
     </Box>
   );
 };
+
+const ShipmentDetail: React.FC = () => {
+  return (
+    <ShipmentDetailProvider>
+      <ShipmentDetailContent />
+    </ShipmentDetailProvider>
+  )
+}
 
 export default ShipmentDetail;

--- a/frontend/admin/src/types.ts
+++ b/frontend/admin/src/types.ts
@@ -358,3 +358,36 @@ export interface ItemDetail {
   unit_price: string;
   total_price: string;
 }
+
+export interface BoxItem {
+  id: string;
+  label: string;
+  length_cm: number;
+  breadth_cm: number;
+  height_cm: number;
+  volumetric_weight?: number;
+  mass_weight?: number;
+}
+
+export interface BoxFormValues {
+  label: string;
+  length: string;
+  breadth: string;
+  height: string;
+  volumetricWeight: string;
+  massWeight: string;
+}
+
+export interface Shipment {
+  id: string;
+  tracking_no: string;
+  shipment_no: string;
+  courier: string;
+  customer: string;
+  customerCode: string;
+  updated_at: string;
+  time: string;
+  user: {
+    name: string;
+  }
+}

--- a/frontend/admin/src/types.ts
+++ b/frontend/admin/src/types.ts
@@ -1,4 +1,5 @@
 import type { UserRole } from "./data/menuItems";
+import type { TRACKING_STATUS } from "./utils/trackingConfig";
 
 export interface UserData {
   id: string;
@@ -390,4 +391,43 @@ export interface Shipment {
   user: {
     name: string;
   }
+}
+
+export type TrackingStatusValue = (typeof TRACKING_STATUS)[keyof typeof TRACKING_STATUS];
+
+export interface PickupActionConfig {
+  label: string;
+  color: 'primary' | 'danger';
+  statusToUpdate?: TrackingStatusValue;
+  requiresModal?: boolean;
+}
+
+export interface PickupUser {
+  id: string;
+  name: string;
+  email?: string;
+  phone_number?: string;
+  suite_no?: string;
+}
+
+export interface TrackingRequest {
+  id: string;
+  status: string;
+  created_at: string;
+}
+
+export interface PickupRequestData {
+  id: string;
+  status: string;
+  pickup_address: string;
+  supplier_name: string;
+  supplier_phone_number: string;
+  pcs_box: number;
+  est_weight: string;
+  pkg_details: string;
+  price?: string;
+  total_mvr?: string;
+  remarks?: string;
+  user: PickupUser;
+  tracking_requests?: TrackingRequest[];
 }

--- a/frontend/admin/src/utils/constants.ts
+++ b/frontend/admin/src/utils/constants.ts
@@ -103,3 +103,12 @@ export const BOX_SHIPMENTS_TABLE_HEADERS = [
   { label: "Date" },
   { label: "", align: "center" as const },
 ];
+
+export const PRE_ARRIVALS_TABLE_HEADERS = [
+  'OTP / Tracking No',
+  'Customer',
+  'ETA',
+  'Created At',
+  'Status',
+  'Actions',
+];

--- a/frontend/admin/src/utils/constants.ts
+++ b/frontend/admin/src/utils/constants.ts
@@ -85,3 +85,21 @@ export const SHIPMENT_MEASUREMENTS_TABLE_HEADERS = [
   'Volumetric Weight(L×W×H)',
   'Label',
 ];
+
+export const SHIPMENT_EXPORT_TABLE_HEADERS = [
+  "Serial #",
+  "Date",
+  "MAWB",
+  "Count",
+  "Created By",
+  "Status",
+  "Actions",
+];
+
+export const BOX_SHIPMENTS_TABLE_HEADERS = [
+  { label: "Shipment No." },
+  { label: "Tracking No." },
+  { label: "Customer" },
+  { label: "Date" },
+  { label: "", align: "center" as const },
+];

--- a/frontend/admin/src/utils/pickupRequestActions.ts
+++ b/frontend/admin/src/utils/pickupRequestActions.ts
@@ -1,0 +1,26 @@
+import { TRACKING_STATUS } from './trackingConfig';
+import type { PickupActionConfig } from '../types';
+
+export const PICKUP_REQUEST_ACTIONS: Record<string, PickupActionConfig[]> = {
+  REQUESTED: [
+    {
+      label: 'Send Quotation',
+      color: 'primary',
+      requiresModal: true,
+    },
+  ],
+  QUOTED: [
+    {
+      label: 'Reject',
+      color: 'danger',
+      statusToUpdate: TRACKING_STATUS.CANCELLED,
+    },
+  ],
+  CONFIRMED: [
+    {
+      label: 'Complete',
+      color: 'primary',
+      statusToUpdate: TRACKING_STATUS.PICKED,
+    },
+  ],
+};

--- a/frontend/admin/src/utils/trackingSteps.ts
+++ b/frontend/admin/src/utils/trackingSteps.ts
@@ -35,3 +35,17 @@ export const SHOPPING_STATUS_TO_STEP_ID_MAPPING: Record<string, string> = {
   PAYMENT_APPROVED: 'PAYMENT_APPROVED',
   ORDER_PLACED: 'ORDER_PLACED',
 };
+
+export const PICKUP_TRACKING_STEPS = [
+  { id: 'REQUESTED', title: 'Requested', description: 'Requested by {userName}' },
+  { id: 'QUOTED', title: 'Quotation Ready', description: 'Quoted for {userName}', defaultDescription: 'Quotation is not ready yet!' },
+  { id: 'CONFIRMED', title: 'Confirmed', description: 'Confirmed by {userName}', defaultDescription: 'Waiting for confirmation!' },
+  { id: 'PICKED', title: 'Picked', description: 'Picked by {userName}', defaultDescription: 'Waiting for complete' },
+];
+
+export const PICKUP_STATUS_TO_STEP_ID_MAPPING: Record<string, string> = {
+  REQUESTED: 'REQUESTED',
+  QUOTED: 'QUOTED',
+  CONFIRMED: 'CONFIRMED',
+  PICKED: 'PICKED',
+};


### PR DESCRIPTION
- Implemented ShipmentDetailContext for shipment detail.
- Wrapped ShipmentDetailContent with ShipmentDetailProvider.
- Updated related files to use the useShipmentDetail without need of passing the props extensively.

Decision: 
I choose Context over the Zustand store because:
- Need to avoid prop drilling
- States only shared across ShipmentDetail and it's realated components
- It does not need to globally available
- States belongs to the one page or feature